### PR TITLE
Retry 50x deploy restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ buildNumber.properties
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
+
+# IntelliJ ignore
+.idea

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.mabl.integration.jenkins.domain.CreateDeploymentPayload;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
+import com.mabl.integration.jenkins.validation.MablRestApiClientRetryHandler;
 import hudson.remoting.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -73,7 +74,7 @@ public class MablRestApiClientImpl implements MablRestApiClient {
 
         httpClient = HttpClients.custom()
                 .setRedirectStrategy(new DefaultRedirectStrategy())
-//                .setRetryHandler() // TODO retry on 50[123] status
+                .setServiceUnavailableRetryStrategy(new MablRestApiClientRetryHandler())
                 // TODO why isn't this setting the required Basic auth headers? Hardcoded as work around.
                 .setDefaultCredentialsProvider(getApiCredentialsProvider(restApiKey))
                 .setUserAgent(PLUGIN_USER_AGENT) // track calls @ API level

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -1,6 +1,7 @@
 package com.mabl.integration.jenkins.validation;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy;
 import org.apache.http.protocol.HttpContext;
 
@@ -10,17 +11,23 @@ import java.util.Arrays;
 import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 501
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
 
-public class MablRestApiClientRetryHandler extends DefaultServiceUnavailableRetryStrategy {
+public class MablRestApiClientRetryHandler implements ServiceUnavailableRetryStrategy {
     private final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(
             SC_NOT_IMPLEMENTED,
             SC_BAD_GATEWAY
     ));
     private final int maxRetries = 5;
+    private final long retryInterval = 1000L;
 
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
         return isRetryStatusCode(response.getStatusLine().getStatusCode())
                 && executionCount <= this.maxRetries;
+    }
+
+    @Override
+    public long getRetryInterval() {
+        return this.retryInterval;
     }
 
     private boolean isRetryStatusCode(int statusCode) {

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -11,7 +11,7 @@ import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 50
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
 
 public class MablRestApiClientRetryHandler extends DefaultServiceUnavailableRetryStrategy {
-    private final ArrayList<Integer> retryStatusCodes = new ArrayList<>(Arrays.asList(SC_NOT_IMPLEMENTED, SC_BAD_GATEWAY));
+    private final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(SC_NOT_IMPLEMENTED, SC_BAD_GATEWAY));
     private final int maxExecutionCount = 5;
 
     @Override

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -11,16 +11,20 @@ import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 50
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
 
 public class MablRestApiClientRetryHandler extends DefaultServiceUnavailableRetryStrategy {
-    private final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(SC_NOT_IMPLEMENTED, SC_BAD_GATEWAY));
-    private final int maxExecutionCount = 5;
+    private final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(
+            SC_NOT_IMPLEMENTED,
+            SC_BAD_GATEWAY
+    ));
+    private final int maxRetries = 5;
 
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
-        return isRetryStatusCode(response.getStatusLine().getStatusCode()) && executionCount < maxExecutionCount;
+        return isRetryStatusCode(response.getStatusLine().getStatusCode())
+                && executionCount <= this.maxRetries;
     }
 
     private boolean isRetryStatusCode(int statusCode) {
-        return retryStatusCodes.contains(statusCode);
+        return this.retryStatusCodes.contains(statusCode);
     }
 
 }

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -2,7 +2,6 @@ package com.mabl.integration.jenkins.validation;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
-import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy;
 import org.apache.http.protocol.HttpContext;
 
 import java.util.ArrayList;
@@ -12,12 +11,12 @@ import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 50
 import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
 
 public class MablRestApiClientRetryHandler implements ServiceUnavailableRetryStrategy {
-    private final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(
+    private static final ArrayList<Integer> retryStatusCodes = new ArrayList<Integer>(Arrays.asList(
             SC_NOT_IMPLEMENTED,
             SC_BAD_GATEWAY
     ));
     private static final int maxRetries = 5;
-    private static final long retryInterval = 1000L;
+    private static final long retryIntervalMillis = 6000L;
 
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
@@ -27,7 +26,7 @@ public class MablRestApiClientRetryHandler implements ServiceUnavailableRetryStr
 
     @Override
     public long getRetryInterval() {
-        return this.retryInterval;
+        return this.retryIntervalMillis;
     }
 
     private boolean isRetryStatusCode(int statusCode) {

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -1,0 +1,26 @@
+package com.mabl.integration.jenkins.validation;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.client.DefaultServiceUnavailableRetryStrategy;
+import org.apache.http.protocol.HttpContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 501
+import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
+
+public class MablRestApiClientRetryHandler extends DefaultServiceUnavailableRetryStrategy {
+    private final ArrayList<Integer> retryStatusCodes = new ArrayList<>(Arrays.asList(SC_NOT_IMPLEMENTED, SC_BAD_GATEWAY));
+    private final int maxExecutionCount = 5;
+
+    @Override
+    public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+        return isRetryStatusCode(response.getStatusLine().getStatusCode()) && executionCount < maxExecutionCount;
+    }
+
+    private boolean isRetryStatusCode(int statusCode) {
+        return retryStatusCodes.contains(statusCode);
+    }
+
+}

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablRestApiClientRetryHandler.java
@@ -16,8 +16,8 @@ public class MablRestApiClientRetryHandler implements ServiceUnavailableRetryStr
             SC_NOT_IMPLEMENTED,
             SC_BAD_GATEWAY
     ));
-    private final int maxRetries = 5;
-    private final long retryInterval = 1000L;
+    private static final int maxRetries = 5;
+    private static final long retryInterval = 1000L;
 
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -7,11 +7,18 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.mabl.integration.jenkins.MablRestApiClientImpl.DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE;
 import static com.mabl.integration.jenkins.MablRestApiClientImpl.REST_API_USERNAME_PLACEHOLDER;
 import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for REST API calls
@@ -185,24 +192,25 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
             final int status,
             final int numTimes
     ) {
-        String state = Scenario.STARTED;
+        String whenState = Scenario.STARTED;
         for(int i=1;i<=numTimes;i++) {
+            String willState = "Requested "+i+" Times";
             stubFor(post(urlEqualTo(postUrl))
                     .inScenario(scenario)
-                    .whenScenarioStateIs(state)
-                    .willSetStateTo("Requested "+i+" Times")
+                    .whenScenarioStateIs(whenState)
+                    .willSetStateTo(willState)
                     .willReturn(aResponse()
                             .withStatus(status)
                             .withHeader("Content-Type", "application/json")
                             .withBody(""+status))
             );
 
-            state = "Requested "+i+" Times";
+            whenState = willState;
         }
 
         stubFor(post(urlEqualTo(postUrl))
                 .inScenario(scenario)
-                .whenScenarioStateIs(state)
+                .whenScenarioStateIs(whenState)
                 .willReturn(aResponse()
                         .withStatus(SC_CREATED)
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
The initial retryer for 501 and 502 status code returns.

Wasn't sure if there was a standard way of referencing constants like the max number of executions so just hardcoded at the top for now. Can be moved to a config if desired.

@twistedpair for review