### PR TITLE
Rich output

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -32,6 +32,7 @@ import static com.mabl.integration.jenkins.MablStepConstants.EXECUTION_STATUS_PO
 import static com.mabl.integration.jenkins.MablStepConstants.EXECUTION_TIMEOUT_SECONDS;
 import static com.mabl.integration.jenkins.MablStepConstants.MABL_REST_API_BASE_URL;
 import static com.mabl.integration.jenkins.MablStepConstants.PLUGIN_SYMBOL;
+import static com.mabl.integration.jenkins.MablStepConstants.TEST_OUTPUT_XML_FILENAME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 
@@ -122,12 +123,12 @@ public class MablStepBuilder extends Builder {
     private FilePath getOutputFileLocation(AbstractBuild<?, ?> build) {
         FilePath fp = build.getWorkspace();
         if (fp == null) {
-            return new FilePath(new File("report.xml"));
+            return new FilePath(new File(TEST_OUTPUT_XML_FILENAME));
         }
         if(fp.isRemote()) {
-            fp = new FilePath(fp.getChannel(), fp.toString() + "/report.xml");
+            fp = new FilePath(fp.getChannel(), fp.toString() + File.separator + TEST_OUTPUT_XML_FILENAME);
         } else {
-            fp = new FilePath(new File(fp.toString() + "/report.xml"));
+            fp = new FilePath(new File(fp.toString() + File.separator + TEST_OUTPUT_XML_FILENAME));
         }
 
         return fp;

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -5,6 +5,7 @@ import com.mabl.integration.jenkins.domain.GetApplicationsResult;
 import com.mabl.integration.jenkins.domain.GetEnvironmentsResult;
 import com.mabl.integration.jenkins.validation.MablStepBuilderValidator;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -17,6 +18,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -91,7 +93,8 @@ public class MablStepBuilder extends Builder {
                 environmentId,
                 applicationId,
                 continueOnPlanFailure,
-                continueOnMablError
+                continueOnMablError,
+                getOutputFileLocation(build)
         );
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -114,6 +117,17 @@ public class MablStepBuilder extends Builder {
     @Override
     public MablStepDescriptor getDescriptor() {
         return (MablStepDescriptor) super.getDescriptor();
+    }
+
+    private FilePath getOutputFileLocation(AbstractBuild<?, ?> build) {
+        FilePath fp;
+        if(build.getWorkspace().isRemote()) {
+            fp = new FilePath(build.getWorkspace().getChannel(), build.getWorkspace().toString() + "/report.xml");
+        } else {
+            fp = new FilePath(new File(build.getWorkspace().toString() + "/report.xml"));
+        }
+
+        return fp;
     }
 
     /**

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -120,11 +120,14 @@ public class MablStepBuilder extends Builder {
     }
 
     private FilePath getOutputFileLocation(AbstractBuild<?, ?> build) {
-        FilePath fp;
-        if(build.getWorkspace().isRemote()) {
-            fp = new FilePath(build.getWorkspace().getChannel(), build.getWorkspace().toString() + "/report.xml");
+        FilePath fp = build.getWorkspace();
+        if (fp == null) {
+            return new FilePath(new File("report.xml"));
+        }
+        if(fp.isRemote()) {
+            fp = new FilePath(fp.getChannel(), fp.toString() + "/report.xml");
         } else {
-            fp = new FilePath(new File(build.getWorkspace().toString() + "/report.xml"));
+            fp = new FilePath(new File(fp.toString() + "/report.xml"));
         }
 
         return fp;

--- a/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
@@ -15,6 +15,7 @@ public class MablStepConstants {
     static final String PLUGIN_VERSION = getPluginVersion();
     static final String PLUGIN_VERSION_UNKNOWN = "unknown";
     static final String PLUGIN_USER_AGENT = "mabl-jenkins-plugin/" + PLUGIN_VERSION;
+    static final String TEST_OUTPUT_XML_FILENAME = "report.xml";
 
     // Label for build steps drop down list
     static final String BUILD_STEP_DISPLAY_NAME = "Run mabl journeys";

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -237,11 +237,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         Date startDate = new Date(summary.startTime);
         Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         String timestamp = format.format(startDate);
-        ArrayList<Property> props = new ArrayList<Property>();
-        props.add(new Property("environmentId", this.environmentId));
-        props.add(new Property("applicationId", this.applicationId));
-
-        return new TestSuite(safePlanName(summary), getDuration(summary), timestamp, new Properties(props));
+        return new TestSuite(safePlanName(summary), getDuration(summary), timestamp);
     }
 
     private long getDuration(ExecutionResult.ExecutionSummary summary) {

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -1,11 +1,10 @@
 package com.mabl.integration.jenkins;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.test.output.Failure;
-import com.mabl.integration.jenkins.test.output.Properties;
-import com.mabl.integration.jenkins.test.output.Property;
 import com.mabl.integration.jenkins.test.output.TestCase;
 import com.mabl.integration.jenkins.test.output.TestSuite;
 import com.mabl.integration.jenkins.test.output.TestSuites;
@@ -22,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -204,7 +204,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
             suites.add(testSuite);
         }
 
-        outputTestSuiteXml(new TestSuites(suites));
+        outputTestSuiteXml(new TestSuites(ImmutableList.copyOf(suites)));
     }
 
     private void printAllJourneyExecutionStatuses(final ExecutionResult result) {
@@ -229,6 +229,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         } catch (IOException e) {
             throw new MablSystemError("There was an error trying to write test results in mabl.", e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new MablSystemError("There was an interruption trying to write test results in mabl.", e);
         }
     }
@@ -236,6 +237,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     private TestSuite getTestSuite(final ExecutionResult.ExecutionSummary summary) {
         Date startDate = new Date(summary.startTime);
         Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        ((SimpleDateFormat) format).setTimeZone(TimeZone.getTimeZone("UTC"));
         String timestamp = format.format(startDate);
         return new TestSuite(safePlanName(summary), getDuration(summary), timestamp);
     }

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -9,16 +9,13 @@ import com.mabl.integration.jenkins.test.output.TestCase;
 import com.mabl.integration.jenkins.test.output.TestSuite;
 import com.mabl.integration.jenkins.test.output.TestSuites;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.text.DateFormat;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -181,45 +178,33 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
 
         outputStream.println("The final Plan states in mabl:");
         for (ExecutionResult.ExecutionSummary summary : result.executions) {
-            long duration = TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS);
-            Date startDate = new Date(summary.startTime);
-            Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            String timestamp = format.format(startDate);
-            TestSuite ts = new TestSuite(safePlanName(summary), duration, timestamp, new Properties());
+            TestSuite testSuite = getTestSuite(summary);
             final String successState = summary.success ? "SUCCESSFUL" : "FAILED";
             outputStream.printf("  Plan [%s] is %s in state [%s]%n", safePlanName(summary), successState, summary.status);
 
             for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
-                TestCase tc;
-                if (journeyResult.success) {
-                    tc = new TestCase(safePlanName(summary), safeJourneyName(summary, journeyResult.id), duration);
-                } else {
+
+                TestCase testCase = new TestCase(
+                        safePlanName(summary),
+                        safeJourneyName(summary, journeyResult.id),
+                        getDuration(summary)
+                );
+
+                testSuite.addToTestCases(testCase);
+                testSuite.incrementTests();
+
+                if (!journeyResult.success) {
                     Failure failure = new Failure(journeyResult.status, journeyResult.statusCause);
-                    tc = new TestCase(safePlanName(summary), safeJourneyName(summary, journeyResult.id), duration, failure);
-                    ts.incrementFailures();
+                    testCase.setFailure(failure);
+                    testSuite.incrementFailures();
                 }
 
-                ts.addToTestCases(tc);
-                ts.incrementTests();
             }
 
-            suites.add(ts);
+            suites.add(testSuite);
         }
 
-        try {
-            TestSuites testSuites = new TestSuites(suites);
-            JAXBContext context = JAXBContext.newInstance(TestSuites.class);
-            Marshaller marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            marshaller.marshal(testSuites, buildPath.write());
-        } catch (JAXBException e) {
-            throw new MablSystemError("There was an error trying to output test results in mabl.", e);
-        } catch (IOException e) {
-            throw new MablSystemError("There was an error trying to write test results in mabl.", e);
-        } catch (InterruptedException e) {
-            throw new MablSystemError("There was an interruption trying to write test results in mabl.", e);
-        }
-
+        outputTestSuiteXml(new TestSuites(suites));
     }
 
     private void printAllJourneyExecutionStatuses(final ExecutionResult result) {
@@ -231,6 +216,32 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
                 outputStream.printf("  Journey [%s] is [%s]%n", safeJourneyName(summary, journeyResult.id), journeyResult.status);
             }
         }
+    }
+
+    private void outputTestSuiteXml(TestSuites testSuites) throws MablSystemError {
+        try {
+            JAXBContext context = JAXBContext.newInstance(TestSuites.class);
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            marshaller.marshal(testSuites, buildPath.write());
+        } catch (JAXBException e) {
+            throw new MablSystemError("There was an error trying to output test results in mabl.", e);
+        } catch (IOException e) {
+            throw new MablSystemError("There was an error trying to write test results in mabl.", e);
+        } catch (InterruptedException e) {
+            throw new MablSystemError("There was an interruption trying to write test results in mabl.", e);
+        }
+    }
+
+    private TestSuite getTestSuite(final ExecutionResult.ExecutionSummary summary) {
+        Date startDate = new Date(summary.startTime);
+        Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String timestamp = format.format(startDate);
+        return new TestSuite(safePlanName(summary), getDuration(summary), timestamp, new Properties());
+    }
+
+    private long getDuration(ExecutionResult.ExecutionSummary summary) {
+        return TimeUnit.SECONDS.convert( (summary.stopTime - summary.startTime), TimeUnit.MILLISECONDS);
     }
 
     private void printException(final Exception exception) {

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -5,6 +5,7 @@ import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.test.output.Failure;
 import com.mabl.integration.jenkins.test.output.Properties;
+import com.mabl.integration.jenkins.test.output.Property;
 import com.mabl.integration.jenkins.test.output.TestCase;
 import com.mabl.integration.jenkins.test.output.TestSuite;
 import com.mabl.integration.jenkins.test.output.TestSuites;
@@ -190,8 +191,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
                         getDuration(summary)
                 );
 
-                testSuite.addToTestCases(testCase);
-                testSuite.incrementTests();
+                testSuite.addToTestCases(testCase).incrementTests();
 
                 if (!journeyResult.success) {
                     Failure failure = new Failure(journeyResult.status, journeyResult.statusCause);
@@ -237,7 +237,11 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         Date startDate = new Date(summary.startTime);
         Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         String timestamp = format.format(startDate);
-        return new TestSuite(safePlanName(summary), getDuration(summary), timestamp, new Properties());
+        ArrayList<Property> props = new ArrayList<Property>();
+        props.add(new Property("environmentId", this.environmentId));
+        props.add(new Property("applicationId", this.applicationId));
+
+        return new TestSuite(safePlanName(summary), getDuration(summary), timestamp, new Properties(props));
     }
 
     private long getDuration(ExecutionResult.ExecutionSummary summary) {

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
@@ -1,13 +1,13 @@
 package com.mabl.integration.jenkins.test.output;
 
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
 
 @XmlRootElement(name = "failure")
 public class Failure {
 
-    @XmlElement(name="reason")
+    @XmlValue()
     private String reason;
 
     @XmlAttribute(name = "message")

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
@@ -1,0 +1,25 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "failure")
+public class Failure {
+
+    @XmlElement(name="reason")
+    private String reason;
+
+    @XmlAttribute(name = "message")
+    private String message;
+
+    public Failure() {
+
+    }
+
+    public Failure(String reason, String message) {
+        this.reason = reason;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Failure.java
@@ -1,10 +1,13 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlValue;
 
 @XmlRootElement(name = "failure")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class Failure {
 
     @XmlValue()
@@ -22,4 +25,11 @@ public class Failure {
         this.message = message;
     }
 
+    public String getMessage() {
+        return message;
+    }
+
+    public String getReason() {
+        return this.reason;
+    }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
@@ -1,0 +1,20 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+
+@XmlRootElement(name = "properties")
+public class Properties {
+
+    @XmlElement(name = "property")
+    private Collection<Property> properties;
+
+    public Properties(Collection<Property> properties) {
+        this.properties = properties;
+    }
+
+    public Properties() {
+
+    }
+}

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
@@ -1,19 +1,20 @@
 package com.mabl.integration.jenkins.test.output;
 
+import com.google.common.collect.ImmutableCollection;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.Collection;
 
 @XmlRootElement(name = "properties")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Properties {
 
     @XmlElement(name = "property")
-    private Collection<Property> properties;
+    private ImmutableCollection<Property> properties;
 
-    public Properties(Collection<Property> properties) {
+    public Properties(ImmutableCollection<Property> properties) {
         this.properties = properties;
     }
 
@@ -21,7 +22,7 @@ public class Properties {
 
     }
 
-    public Collection<Property> getProperties() {
+    public ImmutableCollection<Property> getProperties() {
         return this.properties;
     }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
@@ -1,10 +1,13 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 
 @XmlRootElement(name = "properties")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class Properties {
 
     @XmlElement(name = "property")
@@ -16,5 +19,9 @@ public class Properties {
 
     public Properties() {
 
+    }
+
+    public Collection<Property> getProperties() {
+        return this.properties;
     }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Property.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Property.java
@@ -1,9 +1,12 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "property")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class Property {
 
     @XmlAttribute(name = "name")
@@ -19,5 +22,13 @@ public class Property {
 
     public Property() {
 
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getValue() {
+        return this.value;
     }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Property.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Property.java
@@ -1,0 +1,23 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "property")
+public class Property {
+
+    @XmlAttribute(name = "name")
+    private String name;
+
+    @XmlAttribute(name = "value")
+    private String value;
+
+    public Property(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public Property() {
+
+    }
+}

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
@@ -1,0 +1,38 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "testcase")
+public class TestCase {
+
+    @XmlAttribute(name = "classname")
+    private String plan;
+    @XmlAttribute(name = "name")
+    private String journey;
+    @XmlAttribute(name = "time")
+    private long duration;
+
+    @XmlElement(name = "failure")
+    private Failure failure;
+
+    public TestCase() {
+
+    }
+
+    public TestCase(String plan, String journey, long duration) {
+        this.plan = plan;
+        this.journey = journey;
+        this.duration = duration;
+    }
+
+    public TestCase(String plan, String journey, long duration, Failure failure) {
+        this.plan = plan;
+        this.journey = journey;
+        this.duration = duration;
+        this.failure = failure;
+    }
+}
+
+

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
@@ -33,6 +33,11 @@ public class TestCase {
         this.duration = duration;
         this.failure = failure;
     }
+
+    public TestCase setFailure(Failure failure) {
+        this.failure = failure;
+        return this;
+    }
 }
 
 

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
@@ -1,10 +1,13 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "testcase")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class TestCase {
 
     @XmlAttribute(name = "classname")
@@ -37,6 +40,22 @@ public class TestCase {
     public TestCase setFailure(Failure failure) {
         this.failure = failure;
         return this;
+    }
+
+    public String getPlan() {
+        return this.plan;
+    }
+
+    public String getJourney() {
+        return this.journey;
+    }
+
+    public long getDuration() {
+        return this.duration;
+    }
+
+    public Failure getFailure() {
+        return this.failure;
     }
 }
 

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
@@ -50,19 +50,19 @@ public class TestSuite {
         return this.testCases;
     }
 
-    public int incrementTests() {
+    public TestSuite incrementTests() {
         this.tests++;
-        return this.tests;
+        return this;
     }
 
-    public int incrementErrors() {
+    public TestSuite incrementErrors() {
         this.errors++;
-        return this.errors;
+        return this;
     }
 
-    public int incrementFailures() {
+    public TestSuite incrementFailures() {
         this.failures++;
-        return this.failures;
+        return this;
     }
 
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
@@ -1,0 +1,68 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.Collection;
+
+@XmlRootElement(name="testsuite")
+public class TestSuite {
+
+    @XmlAttribute(name = "name")
+    private String name;
+
+    @XmlAttribute(name = "tests")
+    private int tests;
+
+    @XmlAttribute(name = "errors")
+    private int errors;
+
+    @XmlAttribute(name = "failures")
+    private int failures;
+
+    @XmlAttribute(name = "time")
+    private long time;
+
+    @XmlAttribute(name = "timestamp")
+    private String timestamp;
+
+    @XmlElement(name = "properties")
+    private Properties properties;
+
+    @XmlElement(name = "testcase")
+    private Collection<TestCase> testCases;
+
+    public TestSuite(String name, long time, String timestamp, Properties properties) {
+        this.name = name;
+        this.time = time;
+        this.timestamp = timestamp;
+        this.properties = properties;
+        this.testCases = new ArrayList<TestCase>();
+    }
+
+    public TestSuite() {
+
+    }
+
+    public Collection<TestCase> addToTestCases(TestCase testCase) {
+        this.testCases.add(testCase);
+        return this.testCases;
+    }
+
+    public int incrementTests() {
+        this.tests++;
+        return this.tests;
+    }
+
+    public int incrementErrors() {
+        this.errors++;
+        return this.errors;
+    }
+
+    public int incrementFailures() {
+        this.failures++;
+        return this.failures;
+    }
+
+}

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
@@ -44,6 +44,13 @@ public class TestSuite {
         this.testCases = new ArrayList<TestCase>();
     }
 
+    public TestSuite(String name, long time, String timestamp) {
+        this.name = name;
+        this.time = time;
+        this.timestamp = timestamp;
+        this.testCases = new ArrayList<TestCase>();
+    }
+
     public TestSuite() {
 
     }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuite.java
@@ -1,5 +1,7 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -7,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 @XmlRootElement(name="testsuite")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class TestSuite {
 
     @XmlAttribute(name = "name")
@@ -45,9 +48,9 @@ public class TestSuite {
 
     }
 
-    public Collection<TestCase> addToTestCases(TestCase testCase) {
+    public TestSuite addToTestCases(TestCase testCase) {
         this.testCases.add(testCase);
-        return this.testCases;
+        return this;
     }
 
     public TestSuite incrementTests() {
@@ -63,6 +66,34 @@ public class TestSuite {
     public TestSuite incrementFailures() {
         this.failures++;
         return this;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getTests() {
+        return this.tests;
+    }
+
+    public int getErrors() {
+        return this.errors;
+    }
+
+    public int getFailures() {
+        return this.failures;
+    }
+
+    public long getTime() {
+        return this.time;
+    }
+
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    public Properties getProperties() {
+        return this.properties;
     }
 
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
@@ -1,10 +1,13 @@
 package com.mabl.integration.jenkins.test.output;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
 
 @XmlRootElement(name = "testsuites")
+@XmlAccessorType(XmlAccessType.FIELD)
 public class TestSuites {
 
     @XmlElement(name = "testsuite")

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
@@ -1,0 +1,20 @@
+package com.mabl.integration.jenkins.test.output;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+
+@XmlRootElement(name = "testsuites")
+public class TestSuites {
+
+    @XmlElement(name = "testsuite")
+    private Collection<TestSuite> testSuites;
+
+    public TestSuites(Collection<TestSuite> testSuites) {
+        this.testSuites = testSuites;
+    }
+
+    public TestSuites() {
+
+    }
+}

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
@@ -1,19 +1,20 @@
 package com.mabl.integration.jenkins.test.output;
 
+import com.google.common.collect.ImmutableCollection;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.Collection;
 
 @XmlRootElement(name = "testsuites")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TestSuites {
 
     @XmlElement(name = "testsuite")
-    private Collection<TestSuite> testSuites;
+    private ImmutableCollection<TestSuite> testSuites;
 
-    public TestSuites(Collection<TestSuite> testSuites) {
+    public TestSuites(ImmutableCollection<TestSuite> testSuites) {
         this.testSuites = testSuites;
     }
 

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -2,11 +2,14 @@ package com.mabl.integration.jenkins;
 
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -51,7 +54,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -74,7 +78,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -103,7 +108,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -123,7 +129,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -145,7 +152,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -168,7 +176,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
-                true
+                true,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -188,7 +197,8 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 true,
-                false
+                false,
+                new FilePath(new File("/dev/null"))
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -3,7 +3,6 @@ package com.mabl.integration.jenkins;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +31,7 @@ public class MablStepDeploymentRunnerTest {
     private final String environmentId = "foo-env-e";
     private final String applicationId = "foo-app-a";
     private final String eventId = "foo-event-id";
+    private final FilePath buildPath = new FilePath(new File("/dev/null"));
 
     private MablRestApiClient client;
     private PrintStream outputStream;
@@ -55,7 +55,8 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
+
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -79,7 +80,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -109,7 +110,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -130,7 +131,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -153,7 +154,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -177,7 +178,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 true,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))
@@ -198,7 +199,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 true,
                 false,
-                new FilePath(new File("/dev/null"))
+                buildPath
         );
 
         when(client.createDeploymentEvent(environmentId, applicationId))

--- a/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
@@ -150,7 +150,7 @@ class MablTestConstants {
     static final String TEST_CASE_XML_WITH_FAILURE = "" +
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
             "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\">" +
-                "<failure message=\"My Message\"><reason>My Reason</reason></failure>" +
+                "<failure message=\"My Message\">My Reason</failure>" +
             "</testcase>";
 
     static final String TEST_SUITES_XML = "" +
@@ -166,7 +166,7 @@ class MablTestConstants {
                     "</properties>" +
                     "<testcase classname=\"My Plan Name 1\" name=\"My Journey Name 1\" time=\"11\"/>" +
                     "<testcase classname=\"My Plan Name 2\" name=\"My Journey Name 2\" time=\"22\">" +
-                        "<failure message=\"My Message\"><reason>My Reason</reason></failure>" +
+                        "<failure message=\"My Message\">My Reason</failure>" +
                     "</testcase>" +
                 "</testsuite>" +
             "</testsuites>";

--- a/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
@@ -142,4 +142,33 @@ class MablTestConstants {
             "   ]," +
             "   \"cursor\":\"Cj0SN2oKc35tYWJsLWRldnIpCxILRW52aXJvbm1lbnQiGDd4TlQzQURnZmxUSTJ5TjlJaGprX1EtZQwYACAA\"" +
             "}";
+
+    static final String TEST_CASE_XML = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\"/>";
+
+    static final String TEST_CASE_XML_WITH_FAILURE = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\">" +
+                "<failure message=\"My Message\"><reason>My Reason</reason></failure>" +
+            "</testcase>";
+
+    static final String TEST_SUITES_XML = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<testsuites>" +
+                "<testsuite name=\"Empty Test Suite\" tests=\"0\" errors=\"0\" failures=\"0\" time=\"0\" timestamp=\"2013-05-24T10:23:58\">" +
+                    "<properties/>" +
+                "</testsuite>" +
+                "<testsuite name=\"Full Test Suite\" tests=\"2\" errors=\"0\" failures=\"1\" time=\"33\" timestamp=\"2013-05-24T10:23:58\">" +
+                    "<properties>" +
+                        "<property name=\"environment\" value=\"my env-e\"/>" +
+                        "<property name=\"application\" value=\"my app-a\"/>" +
+                    "</properties>" +
+                    "<testcase classname=\"My Plan Name 1\" name=\"My Journey Name 1\" time=\"11\"/>" +
+                    "<testcase classname=\"My Plan Name 2\" name=\"My Journey Name 2\" time=\"22\">" +
+                        "<failure message=\"My Message\"><reason>My Reason</reason></failure>" +
+                    "</testcase>" +
+                "</testsuite>" +
+            "</testsuites>";
+
 }

--- a/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
+++ b/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
@@ -1,5 +1,6 @@
 package com.mabl.integration.jenkins;
 
+import com.google.common.collect.ImmutableList;
 import com.mabl.integration.jenkins.test.output.Failure;
 import com.mabl.integration.jenkins.test.output.Properties;
 import com.mabl.integration.jenkins.test.output.Property;
@@ -53,7 +54,7 @@ public class TestOutputTests {
         ArrayList<Property> props = new ArrayList<Property>();
         props.add(property1);
         props.add(property2);
-        Properties properties = new Properties(props);
+        Properties properties = new Properties(ImmutableList.copyOf(props));
 
         TestCase testCase1 = new TestCase("My Plan Name 1", "My Journey Name 1", 11L);
         Failure failure = new Failure("My Reason", "My Message");
@@ -73,7 +74,7 @@ public class TestOutputTests {
         ArrayList<TestSuite> suites = new ArrayList<TestSuite>();
         suites.add(emptyTestSuite);
         suites.add(testSuite1);
-        TestSuites testSuites = new TestSuites(suites);
+        TestSuites testSuites = new TestSuites(ImmutableList.copyOf(suites));
 
         JAXBContext jaxbContext = JAXBContext.newInstance(TestSuites.class);
         Marshaller marshaller = jaxbContext.createMarshaller();

--- a/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
+++ b/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
@@ -1,0 +1,85 @@
+package com.mabl.integration.jenkins;
+
+import com.mabl.integration.jenkins.test.output.Failure;
+import com.mabl.integration.jenkins.test.output.Properties;
+import com.mabl.integration.jenkins.test.output.Property;
+import com.mabl.integration.jenkins.test.output.TestCase;
+import com.mabl.integration.jenkins.test.output.TestSuite;
+import com.mabl.integration.jenkins.test.output.TestSuites;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestOutputTests {
+
+    @Test
+    public void testTestCaseOutputNoFailure() throws JAXBException {
+        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L);
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testCase, stringWriter);
+        assertEquals(MablTestConstants.TEST_CASE_XML, stringWriter.toString());
+    }
+
+    @Test
+    public void testTestCaseOutputWithFailure() throws JAXBException {
+        Failure failure = new Failure("My Reason", "My Message");
+        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L, failure);
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testCase, stringWriter);
+        assertEquals(MablTestConstants.TEST_CASE_XML_WITH_FAILURE, stringWriter.toString());
+    }
+
+    @Test
+    public void testEntireTestSuite() throws JAXBException {
+        TestSuite emptyTestSuite = new TestSuite(
+                "Empty Test Suite",
+                0L,
+                "2013-05-24T10:23:58",
+                new Properties()
+        );
+
+        Property property1 = new Property("environment", "my env-e");
+        Property property2 = new Property("application", "my app-a");
+        ArrayList<Property> props = new ArrayList<Property>();
+        props.add(property1);
+        props.add(property2);
+        Properties properties = new Properties(props);
+
+        TestCase testCase1 = new TestCase("My Plan Name 1", "My Journey Name 1", 11L);
+        Failure failure = new Failure("My Reason", "My Message");
+        TestCase testCase2 = new TestCase("My Plan Name 2", "My Journey Name 2", 22L, failure);
+        TestSuite testSuite1 = new TestSuite(
+                "Full Test Suite",
+                33L,
+                "2013-05-24T10:23:58",
+                properties
+        );
+        testSuite1.addToTestCases(testCase1);
+        testSuite1.incrementTests();
+        testSuite1.addToTestCases(testCase2);
+        testSuite1.incrementTests();
+        testSuite1.incrementFailures();
+
+        ArrayList<TestSuite> suites = new ArrayList<TestSuite>();
+        suites.add(emptyTestSuite);
+        suites.add(testSuite1);
+        TestSuites testSuites = new TestSuites(suites);
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(TestSuites.class);
+        Marshaller marshaller = jaxbContext.createMarshaller();
+        StringWriter stringWriter = new StringWriter();
+        marshaller.marshal(testSuites, stringWriter);
+        assertEquals(MablTestConstants.TEST_SUITES_XML, stringWriter.toString());
+    }
+}

--- a/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
+++ b/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
@@ -13,7 +13,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
Now output mabl tests in junit test xml form to the workspace dir for inspection and reports.

Here is an example output

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<testsuites>
    <testsuite name="Prod Verify" tests="3" errors="0" failures="1" time="69" timestamp="2018-06-05T15:32:33">
        <testcase classname="Prod Verify" name="Login" time="69"/>
        <testcase classname="Prod Verify" name="Logout" time="69">
            <failure>failed</failure>
        </testcase>
        <testcase classname="Prod Verify" name="Visit home page" time="69"/>
    </testsuite>
</testsuites>
```

testsuite.name && testcase.classname is the name of the mabl Plan
testcase.name it the Journey name
testsuite.time && testcase.time are the overall plan's execution time in seconds

Right now the output file for every deployment is output.xml (so a new one overwrites old ones.) It could be disired to have each run make a new file?

Using a post-build action of "Publish JUnit test result report" you can see the results in Jenkins. (I used `**/*.xml` as my test report XMLs, everything else default)

Here is a glimpse as to what it will look like:

![jenkinstestoutput](https://user-images.githubusercontent.com/835911/40980128-c03b8d88-68a5-11e8-9e56-717bece66e59.png)
