### PR TITLE
Initial work for deployment source

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/Converter.java
+++ b/src/main/java/com/mabl/integration/jenkins/Converter.java
@@ -1,0 +1,51 @@
+package com.mabl.integration.jenkins;
+
+import com.google.common.base.Strings;
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
+import hudson.EnvVars;
+
+import java.util.Map;
+
+public class Converter {
+
+    public static CreateDeploymentProperties convert(EnvVars vars) {
+        CreateDeploymentProperties props = new CreateDeploymentProperties();
+
+        // Repository specific props (Only exists because of other non-mabl steps)
+        props.setRepositoryBranchName(getProperty(vars, "GIT_BRANCH"));
+        props.setRepositoryRevisionNumber(getProperty(vars, "GIT_COMMIT", "SVN_REVISION"));
+        String repoUrl = getProperty(vars, "GIT_URL", "SVN_URL");
+        props.setRepositoryUrl(repoUrl);
+        props.setRepositoryName(getRepositoryName(repoUrl));
+        props.setRepositoryPreviousRevisionNumber(getProperty(vars, "GIT_PREVIOUS_COMMIT"));
+        //props.setRepositoryCommitUsername(getProperty(vars, ""));
+
+        // Jenkins info about the mabl step that should be there no matter what
+        props.setBuildPlanId(getProperty(vars, "JOB_NAME"));
+        props.setBuildPlanName(getProperty(vars, "JOB_NAME"));
+        props.setBuildPlanNumber(getProperty(vars, "BUILD_NUMBER"));
+        props.setBuildPlanResultUrl(getProperty(vars, "RUN_DISPLAY_URL"));
+
+        return props;
+    }
+
+    private static <String> String getProperty(Map<String, String> vars, String ...possibleProperties) {
+        for(String property : possibleProperties) {
+            if(vars.containsKey(property)) {
+                return vars.get(property);
+            }
+        }
+
+        return null;
+    }
+
+    private static String getRepositoryName(String repoUrl) {
+        if(!Strings.isNullOrEmpty(repoUrl)) {
+            String[] segments = repoUrl.split("/");
+            String ending = segments[segments.length -1];
+            return ending.endsWith(".git") ? ending.substring(0, ending.length() - 4) : ending;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/mabl/integration/jenkins/Converter.java
+++ b/src/main/java/com/mabl/integration/jenkins/Converter.java
@@ -4,34 +4,36 @@ import com.google.common.base.Strings;
 import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import hudson.EnvVars;
 
+import java.io.PrintStream;
 import java.util.Map;
 
 public class Converter {
 
-    public static CreateDeploymentProperties convert(EnvVars vars) {
+    public static CreateDeploymentProperties convert(EnvVars vars, PrintStream outputStream) {
         CreateDeploymentProperties props = new CreateDeploymentProperties();
 
         // Repository specific props (Only exists because of other non-mabl steps)
-        props.setRepositoryBranchName(getProperty(vars, "GIT_BRANCH"));
-        props.setRepositoryRevisionNumber(getProperty(vars, "GIT_COMMIT", "SVN_REVISION"));
-        String repoUrl = getProperty(vars, "GIT_URL", "SVN_URL");
+        props.setRepositoryBranchName(getProperty(vars, outputStream, "GIT_BRANCH"));
+        props.setRepositoryRevisionNumber(getProperty(vars, outputStream, "GIT_COMMIT", "SVN_REVISION"));
+        String repoUrl = getProperty(vars, outputStream, "GIT_URL", "SVN_URL");
         props.setRepositoryUrl(repoUrl);
         props.setRepositoryName(getRepositoryName(repoUrl));
-        props.setRepositoryPreviousRevisionNumber(getProperty(vars, "GIT_PREVIOUS_COMMIT"));
-        //props.setRepositoryCommitUsername(getProperty(vars, ""));
+        props.setRepositoryPreviousRevisionNumber(getProperty(vars, outputStream, "GIT_PREVIOUS_COMMIT"));
+        //props.setRepositoryCommitUsername(getProperty(vars, outputStream, ""));
 
         // Jenkins info about the mabl step that should be there no matter what
-        props.setBuildPlanId(getProperty(vars, "JOB_NAME"));
-        props.setBuildPlanName(getProperty(vars, "JOB_NAME"));
-        props.setBuildPlanNumber(getProperty(vars, "BUILD_NUMBER"));
-        props.setBuildPlanResultUrl(getProperty(vars, "RUN_DISPLAY_URL"));
+        props.setBuildPlanId(getProperty(vars, outputStream, "JOB_NAME"));
+        props.setBuildPlanName(getProperty(vars, outputStream, "JOB_NAME"));
+        props.setBuildPlanNumber(getProperty(vars, outputStream, "BUILD_NUMBER"));
+        props.setBuildPlanResultUrl(getProperty(vars, outputStream, "RUN_DISPLAY_URL"));
 
         return props;
     }
 
-    private static <String> String getProperty(Map<String, String> vars, String ...possibleProperties) {
+    private static <String> String getProperty(Map<String, String> vars, PrintStream stream, String ...possibleProperties) {
         for(String property : possibleProperties) {
             if(vars.containsKey(property)) {
+                stream.printf("  '%s' => '%s'%n", property, vars.get(property));
                 return vars.get(property);
             }
         }

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClient.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClient.java
@@ -1,5 +1,6 @@
 package com.mabl.integration.jenkins;
 
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.domain.GetApiKeyResult;
@@ -12,7 +13,8 @@ public interface MablRestApiClient {
 
     CreateDeploymentResult createDeploymentEvent(
             String environmentId,
-            String applicationId
+            String applicationId,
+            CreateDeploymentProperties properties
     ) throws IOException, MablSystemError;
 
     /**

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.mabl.integration.jenkins.domain.CreateDeploymentPayload;
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.domain.GetApiKeyResult;
@@ -118,13 +119,13 @@ public class MablRestApiClientImpl implements MablRestApiClient {
     @Override
     public CreateDeploymentResult createDeploymentEvent(
             final String environmentId,
-            final String applicationId
-    ) throws IOException, MablSystemError {
-
+            final String applicationId,
+            final CreateDeploymentProperties properties
+            ) throws IOException, MablSystemError {
         final String url = restApiBaseUrl + DEPLOYMENT_TRIGGER_ENDPOINT; // TODO validate inputs so we can't have illegal urls
 
         // TODO do sanity check of parameters, so we can catch the encoding exception
-        final String jsonPayload = objectMapper.writeValueAsString(new CreateDeploymentPayload(environmentId, applicationId));
+        final String jsonPayload = objectMapper.writeValueAsString(new CreateDeploymentPayload(environmentId, applicationId, properties));
         final AbstractHttpEntity payloadEntity = new ByteArrayEntity(jsonPayload.getBytes("UTF-8"));
 
         final HttpPost request = new HttpPost(url);

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -4,6 +4,7 @@ import com.mabl.integration.jenkins.domain.GetApiKeyResult;
 import com.mabl.integration.jenkins.domain.GetApplicationsResult;
 import com.mabl.integration.jenkins.domain.GetEnvironmentsResult;
 import com.mabl.integration.jenkins.validation.MablStepBuilderValidator;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -95,7 +96,8 @@ public class MablStepBuilder extends Builder {
                 applicationId,
                 continueOnPlanFailure,
                 continueOnMablError,
-                getOutputFileLocation(build)
+                getOutputFileLocation(build),
+                getEnvironmentVars(build, listener)
         );
 
         ExecutorService executorService = Executors.newSingleThreadExecutor();
@@ -132,6 +134,21 @@ public class MablStepBuilder extends Builder {
         }
 
         return fp;
+    }
+
+    private EnvVars getEnvironmentVars(AbstractBuild<?, ?> build, BuildListener listener) {
+        final PrintStream outputStream = listener.getLogger();
+        EnvVars environmentVars = new EnvVars();
+        try {
+            environmentVars = build.getEnvironment(listener);
+        } catch (IOException e) {
+            outputStream.println(e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            outputStream.println(e.getMessage());
+        }
+
+        return environmentVars;
     }
 
     /**

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -2,12 +2,14 @@ package com.mabl.integration.jenkins;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.test.output.Failure;
 import com.mabl.integration.jenkins.test.output.TestCase;
 import com.mabl.integration.jenkins.test.output.TestSuite;
 import com.mabl.integration.jenkins.test.output.TestSuites;
+import hudson.EnvVars;
 import hudson.FilePath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -54,6 +56,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     private final boolean continueOnPlanFailure;
     private final boolean continueOnMablError;
     private final FilePath buildPath;
+    private final EnvVars environmentVars;
 
     @SuppressWarnings("WeakerAccess") // required public for DataBound
     @DataBoundConstructor
@@ -65,7 +68,8 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
             final String applicationId,
             final boolean continueOnPlanFailure,
             final boolean continueOnMablError,
-            final FilePath buildPath
+            final FilePath buildPath,
+            final EnvVars environmentVars
 
     ) {
         this.outputStream = outputStream;
@@ -76,6 +80,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         this.continueOnPlanFailure = continueOnPlanFailure;
         this.continueOnMablError = continueOnMablError;
         this.buildPath = buildPath;
+        this.environmentVars = environmentVars;
     }
 
     @Override
@@ -112,7 +117,8 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         );
 
         try {
-            final CreateDeploymentResult deployment = client.createDeploymentEvent(environmentId, applicationId);
+            final CreateDeploymentProperties properties = getDeploymentProperties();
+            final CreateDeploymentResult deployment = client.createDeploymentEvent(environmentId, applicationId, properties);
             outputStream.printf("Deployment event was created with id [%s] in mabl.%n", deployment.id);
 
             try {
@@ -152,6 +158,13 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
                 client.close();
             }
         }
+    }
+
+    private CreateDeploymentProperties getDeploymentProperties() {
+        CreateDeploymentProperties properties = Converter.convert(this.environmentVars);
+        properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+
+        return properties;
     }
 
     private boolean allPlansComplete(final ExecutionResult result) {

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -55,6 +55,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     private final String applicationId;
     private final boolean continueOnPlanFailure;
     private final boolean continueOnMablError;
+    private final boolean collectVars;
     private final FilePath buildPath;
     private final EnvVars environmentVars;
 
@@ -68,6 +69,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
             final String applicationId,
             final boolean continueOnPlanFailure,
             final boolean continueOnMablError,
+            final boolean collectVars,
             final FilePath buildPath,
             final EnvVars environmentVars
 
@@ -79,6 +81,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         this.applicationId = applicationId;
         this.continueOnPlanFailure = continueOnPlanFailure;
         this.continueOnMablError = continueOnMablError;
+        this.collectVars = collectVars;
         this.buildPath = buildPath;
         this.environmentVars = environmentVars;
     }
@@ -161,9 +164,15 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     }
 
     private CreateDeploymentProperties getDeploymentProperties() {
-        CreateDeploymentProperties properties = Converter.convert(this.environmentVars);
-        properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+        CreateDeploymentProperties properties = Converter.convert(new EnvVars(), outputStream);
+        if(collectVars) {
+            outputStream.print("Send build environment variables is set. Collecting the following information:%n");
+            properties = Converter.convert(this.environmentVars, outputStream);
+        } else {
+            outputStream.print("Send build environment variables is unset. Not collecting any environment information:%n");
+        }
 
+        properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
         return properties;
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentPayload.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentPayload.java
@@ -3,9 +3,11 @@ package com.mabl.integration.jenkins.domain;
 public class CreateDeploymentPayload {
     final String environmentId;
     final String applicationId;
+    final CreateDeploymentProperties properties;
 
-    public CreateDeploymentPayload(String environmentId, String applicationId) {
+    public CreateDeploymentPayload(String environmentId, String applicationId, CreateDeploymentProperties properties) {
         this.environmentId = environmentId;
         this.applicationId = applicationId;
+        this.properties = properties;
     }
 }

--- a/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
@@ -1,7 +1,7 @@
 package com.mabl.integration.jenkins.domain;
 
 public class CreateDeploymentProperties {
-    public String deploymentOrigin;
+    private String deploymentOrigin;
     private String repositoryBranchName;
     private String repositoryRevisionNumber;
     private String repositoryUrl;
@@ -12,6 +12,50 @@ public class CreateDeploymentProperties {
     private String buildPlanName;
     private String buildPlanNumber;
     private String buildPlanResultUrl;
+
+    public String getDeploymentOrigin() {
+        return deploymentOrigin;
+    }
+
+    public String getRepositoryBranchName() {
+        return repositoryBranchName;
+    }
+
+    public String getRepositoryRevisionNumber() {
+        return repositoryRevisionNumber;
+    }
+
+    public String getRepositoryUrl() {
+        return repositoryUrl;
+    }
+
+    public String getRepositoryName() {
+        return repositoryName;
+    }
+
+    public String getRepositoryPreviousRevisionNumber() {
+        return repositoryPreviousRevisionNumber;
+    }
+
+    public String getRepositoryCommitUsername() {
+        return repositoryCommitUsername;
+    }
+
+    public String getBuildPlanId() {
+        return buildPlanId;
+    }
+
+    public String getBuildPlanName() {
+        return buildPlanName;
+    }
+
+    public String getBuildPlanNumber() {
+        return buildPlanNumber;
+    }
+
+    public String getBuildPlanResultUrl() {
+        return buildPlanResultUrl;
+    }
 
     public void setDeploymentOrigin(String plugin) {
         this.deploymentOrigin = plugin;

--- a/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
@@ -1,0 +1,62 @@
+package com.mabl.integration.jenkins.domain;
+
+public class CreateDeploymentProperties {
+    public String deploymentOrigin;
+    private String repositoryBranchName;
+    private String repositoryRevisionNumber;
+    private String repositoryUrl;
+    private String repositoryName;
+    private String repositoryPreviousRevisionNumber;
+    private String repositoryCommitUsername;
+    private String buildPlanId;
+    private String buildPlanName;
+    private String buildPlanNumber;
+    private String buildPlanResultUrl;
+
+    public void setDeploymentOrigin(String plugin) {
+        this.deploymentOrigin = plugin;
+    }
+
+    public void setRepositoryBranchName(String repositoryBranchName) {
+        this.repositoryBranchName = repositoryBranchName;
+    }
+
+    public void setRepositoryRevisionNumber(String repositoryRevisionNumber) {
+        this.repositoryRevisionNumber = repositoryRevisionNumber;
+    }
+
+    public void setRepositoryUrl(String repositoryUrl) {
+        this.repositoryUrl = repositoryUrl;
+    }
+
+    public void setRepositoryName(String repositoryName) {
+        this.repositoryName = repositoryName;
+    }
+
+    public void setRepositoryPreviousRevisionNumber(String repositoryPreviousRevisionNumber) {
+        this.repositoryPreviousRevisionNumber = repositoryPreviousRevisionNumber;
+    }
+
+    public void setRepositoryCommitUsername(String repositoryCommitUsername) {
+        this.repositoryCommitUsername = repositoryCommitUsername;
+    }
+
+    public void setBuildPlanId(String buildPlanId) {
+        this.buildPlanId = buildPlanId;
+    }
+
+    public void setBuildPlanName(String buildPlanName) {
+        this.buildPlanName = buildPlanName;
+    }
+
+    public void setBuildPlanNumber(String buildPlanNumber) {
+        this.buildPlanNumber = buildPlanNumber;
+    }
+
+    public void setBuildPlanResultUrl(String buildPlanResultUrl) {
+        this.buildPlanResultUrl = buildPlanResultUrl;
+    }
+
+
+}
+

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/global.jelly
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/global.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:section title="mabl" name="mabl">
+        <f:entry title="${%Send build environment variables to mabl}">
+            <f:checkbox field="collectVars" default="true" checked="${descriptor.isCollectVars()}"/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/test/java/com/mabl/integration/jenkins/ConverterTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/ConverterTest.java
@@ -1,0 +1,46 @@
+package com.mabl.integration.jenkins;
+
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
+import hudson.EnvVars;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConverterTest {
+
+    @Test
+    public void testJustBuildVars() {
+        assertSuccessfulConversion(MablTestConstants.JUST_BUILD_PROPS, Converter.convert(new EnvVars().overrideAll(MablTestConstants.BUILD_VARS), System.out));
+    }
+
+    @Test
+    public void testGitBuildVars() {
+        assertSuccessfulConversion(MablTestConstants.GIT_BUILD_PROPS_SSH, Converter.convert(new EnvVars().overrideAll(MablTestConstants.GIT_VARS), System.out));
+    }
+
+    @Test
+    public void testGitBuildVarsHttpsUrl() {
+        EnvVars envVars = new EnvVars().overrideAll(MablTestConstants.GIT_VARS);
+        envVars.override("GIT_URL", "https://github.com/fakeOrg/mabl-integration-plugin.git");
+        assertSuccessfulConversion(MablTestConstants.GIT_BUILD_PROPS_HTTPS, Converter.convert(envVars, System.out));
+    }
+
+    @Test
+    public void testSvnBuildVars() {
+        assertSuccessfulConversion(MablTestConstants.SVN_BUILD_PROPS, Converter.convert(new EnvVars().overrideAll(MablTestConstants.SVN_VARS), System.out));
+    }
+
+    private void assertSuccessfulConversion(CreateDeploymentProperties expected, CreateDeploymentProperties actual){
+        assertEquals(expected.getDeploymentOrigin(), expected.getDeploymentOrigin());
+        assertEquals(expected.getBuildPlanId(), actual.getBuildPlanId());
+        assertEquals(expected.getBuildPlanName(), actual.getBuildPlanName());
+        assertEquals(expected.getBuildPlanNumber(), actual.getBuildPlanNumber());
+        assertEquals(expected.getBuildPlanResultUrl(), actual.getBuildPlanResultUrl());
+        assertEquals(expected.getRepositoryUrl(), actual.getRepositoryUrl());
+        assertEquals(expected.getRepositoryName(), actual.getRepositoryName());
+        assertEquals(expected.getRepositoryBranchName(), actual.getRepositoryBranchName());
+        assertEquals(expected.getRepositoryRevisionNumber(), actual.getRepositoryRevisionNumber());
+        assertEquals(expected.getRepositoryCommitUsername(), expected.getRepositoryCommitUsername());
+        assertEquals(expected.getRepositoryPreviousRevisionNumber(), expected.getRepositoryPreviousRevisionNumber());
+    }
+}

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -3,6 +3,7 @@ package com.mabl.integration.jenkins;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.domain.GetApiKeyResult;
@@ -35,6 +36,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
     private static final String EXPECTED_DEPLOYMENT_EVENT_ID = "d1To4-GYeZ4nl-4Ag1JyQg-v";
     private static final String EXPECTED_ORGANIZATION_ID = "K8NWhtPqOyFnyvJTvCP0uw-w";
+    private static final String fakeProperties = "{\"deployment_origin\":\""+MablStepConstants.PLUGIN_USER_AGENT+"\"}";
 
     @Test
     public void createDeploymentAllParametersHappyPathTest() throws IOException, MablSystemError {
@@ -43,12 +45,13 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
         final String environmentId = "foo-env-e";
         final String applicationId = "foo-app-a";
 
+
         registerPostMapping(
                 MablRestApiClientImpl.DEPLOYMENT_TRIGGER_ENDPOINT,
                 MablTestConstants.CREATE_DEPLOYMENT_EVENT_RESULT_JSON,
                 REST_API_USERNAME_PLACEHOLDER,
                 fakeRestApiKey,
-                "{\"environment_id\":\"foo-env-e\",\"application_id\":\"foo-app-a\"}"
+                "{\"environment_id\":\"foo-env-e\",\"application_id\":\"foo-app-a\",\"properties\":"+fakeProperties+"}"
         );
 
         assertSuccessfulCreateDeploymentRequest(fakeRestApiKey, environmentId, applicationId);
@@ -66,7 +69,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
                 MablTestConstants.CREATE_DEPLOYMENT_EVENT_RESULT_JSON,
                 REST_API_USERNAME_PLACEHOLDER,
                 fakeRestApiKey,
-                "{\"environment_id\":\"foo-env-e\"}"
+                "{\"environment_id\":\"foo-env-e\",\"properties\":"+fakeProperties+"}"
         );
 
         assertSuccessfulCreateDeploymentRequest(fakeRestApiKey, environmentId, applicationId);
@@ -84,7 +87,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
                 MablTestConstants.CREATE_DEPLOYMENT_EVENT_RESULT_JSON,
                 REST_API_USERNAME_PLACEHOLDER,
                 fakeRestApiKey,
-                "{\"application_id\":\"foo-app-a\"}"
+                "{\"application_id\":\"foo-app-a\",\"properties\":"+fakeProperties+"}"
         );
 
         assertSuccessfulCreateDeploymentRequest(fakeRestApiKey, environmentId, applicationId);
@@ -101,7 +104,9 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
         MablRestApiClient client = null;
         try {
             client = new MablRestApiClientImpl(baseUrl, restApiKey);
-            CreateDeploymentResult result = client.createDeploymentEvent(environmentId, applicationId);
+            CreateDeploymentProperties properties = new CreateDeploymentProperties();
+            properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+            CreateDeploymentResult result = client.createDeploymentEvent(environmentId, applicationId, properties);
             assertEquals(EXPECTED_DEPLOYMENT_EVENT_ID, result.id);
         } finally {
             if (client != null) {

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -38,6 +38,7 @@ public class MablStepDeploymentRunnerTest {
     private final FilePath buildPath = new FilePath(new File("/dev/null"));
     private final EnvVars envVars = new EnvVars();
 
+    private MablStepDeploymentRunner runner;
     private MablRestApiClient client;
     private PrintStream outputStream;
 
@@ -48,11 +49,7 @@ public class MablStepDeploymentRunnerTest {
     public void setup() {
         client = mock(MablRestApiClient.class);
         outputStream = mock(PrintStream.class);
-    }
-
-    @Test
-    public void runTestsHappyPath() throws IOException, MablSystemError {
-        MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
+        runner = new MablStepDeploymentRunner(
                 client,
                 outputStream,
                 TEST_POLLING_INTERVAL_MILLISECONDS,
@@ -60,11 +57,14 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
+                true,
                 buildPath,
                 envVars
-
         );
+    }
 
+    @Test
+    public void runTestsHappyPath() throws IOException, MablSystemError {
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
@@ -78,18 +78,6 @@ public class MablStepDeploymentRunnerTest {
 
     @Test
     public void runTestsHappyPathManyPollings() throws IOException, MablSystemError {
-        MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
-                client,
-                outputStream,
-                TEST_POLLING_INTERVAL_MILLISECONDS,
-                environmentId,
-                applicationId,
-                false,
-                false,
-                buildPath,
-                envVars
-        );
-
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
@@ -109,18 +97,6 @@ public class MablStepDeploymentRunnerTest {
 
     @Test
     public void runTestsMablErrorOnCreateDeployment() throws IOException, MablSystemError {
-        MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
-                client,
-                outputStream,
-                TEST_POLLING_INTERVAL_MILLISECONDS,
-                environmentId,
-                applicationId,
-                false,
-                false,
-                buildPath,
-                envVars
-        );
-
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenThrow(new MablSystemError("mabl error"));
 
@@ -131,18 +107,6 @@ public class MablStepDeploymentRunnerTest {
 
     @Test
     public void runTestsMablErrorDeploymentResultsNotFound() throws IOException, MablSystemError {
-        MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
-                client,
-                outputStream,
-                TEST_POLLING_INTERVAL_MILLISECONDS,
-                environmentId,
-                applicationId,
-                false,
-                false,
-                buildPath,
-                envVars
-        );
-
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenThrow(new MablSystemError("mabl error"));
 
@@ -155,18 +119,6 @@ public class MablStepDeploymentRunnerTest {
 
     @Test
     public void runTestsPlanFailure() throws IOException, MablSystemError {
-        MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
-                client,
-                outputStream,
-                TEST_POLLING_INTERVAL_MILLISECONDS,
-                environmentId,
-                applicationId,
-                false,
-                false,
-                buildPath,
-                envVars
-        );
-
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
@@ -187,6 +139,7 @@ public class MablStepDeploymentRunnerTest {
                 environmentId,
                 applicationId,
                 false,
+                true,
                 true,
                 buildPath,
                 envVars
@@ -210,6 +163,7 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 true,
                 false,
+                true,
                 buildPath,
                 envVars
         );

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -1,7 +1,9 @@
 package com.mabl.integration.jenkins;
 
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
 import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
 import com.mabl.integration.jenkins.domain.ExecutionResult;
+import hudson.EnvVars;
 import hudson.FilePath;
 import org.junit.Before;
 import org.junit.Rule;
@@ -16,6 +18,8 @@ import java.util.ArrayList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +36,7 @@ public class MablStepDeploymentRunnerTest {
     private final String applicationId = "foo-app-a";
     private final String eventId = "foo-event-id";
     private final FilePath buildPath = new FilePath(new File("/dev/null"));
+    private final EnvVars envVars = new EnvVars();
 
     private MablRestApiClient client;
     private PrintStream outputStream;
@@ -55,11 +60,12 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                buildPath
+                buildPath,
+                envVars
 
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
         when(client.getExecutionResults(eventId))
@@ -80,10 +86,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
         when(client.getExecutionResults(eventId))
@@ -110,10 +117,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenThrow(new MablSystemError("mabl error"));
 
         assertFalse("failure outcome expected", runner.call());
@@ -131,10 +139,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenThrow(new MablSystemError("mabl error"));
 
         when(client.getExecutionResults(eventId)).thenReturn(null);
@@ -154,10 +163,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 false,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
         when(client.getExecutionResults(eventId))
@@ -178,10 +188,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 false,
                 true,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenThrow(new MablSystemError("mabl error"));
 
         assertTrue("failure override expected", runner.call());
@@ -199,10 +210,11 @@ public class MablStepDeploymentRunnerTest {
                 applicationId,
                 true,
                 false,
-                buildPath
+                buildPath,
+                envVars
         );
 
-        when(client.createDeploymentEvent(environmentId, applicationId))
+        when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), any(CreateDeploymentProperties.class)))
                 .thenReturn(new CreateDeploymentResult(eventId));
 
         when(client.getExecutionResults(eventId))

--- a/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
@@ -1,5 +1,10 @@
 package com.mabl.integration.jenkins;
 
+import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * mabl custom build step
  *
@@ -171,4 +176,82 @@ class MablTestConstants {
                 "</testsuite>" +
             "</testsuites>";
 
+    static final Map<String, String> BUILD_VARS = new HashMap<String, String> () {
+        {
+            put("JOB_NAME", "MyFakeJobName");
+            put("BUILD_NUMBER", "6");
+            put("RUN_DISPLAY_URL", "http://server/job/FakeJobName/6/display/redirect");
+        }
+    };
+
+    static final Map<String, String> GIT_VARS = new HashMap<String, String>() {
+        {
+            put("GIT_BRANCH", "master");
+            put("GIT_COMMIT", "1234");
+            put("GIT_URL", "git@github.com:fakeOrg/mabl-integration-plugin.git");
+            put("GIT_PREVIOUS_COMMIT", "1233");
+            putAll(BUILD_VARS);
+        }
+    };
+
+    static final Map<String, String> SVN_VARS = new HashMap<String, String>() {
+        {
+            put("SVN_REVISION", "12");
+            put("SVN_URL", "https://svn.fakeDomain.com/int_test_svn");
+            putAll(BUILD_VARS);
+        }
+    };
+
+    static final CreateDeploymentProperties JUST_BUILD_PROPS = new CreateDeploymentProperties() {
+        {
+            setBuildPlanId("MyFakeJobName");
+            setBuildPlanName("MyFakeJobName");
+            setBuildPlanNumber("6");
+            setBuildPlanResultUrl("http://server/job/FakeJobName/6/display/redirect");
+            setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+        }
+    };
+
+    static final CreateDeploymentProperties GIT_BUILD_PROPS_SSH = new CreateDeploymentProperties() {
+        {
+            setBuildPlanId("MyFakeJobName");
+            setBuildPlanName("MyFakeJobName");
+            setBuildPlanNumber("6");
+            setBuildPlanResultUrl("http://server/job/FakeJobName/6/display/redirect");
+            setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+            setRepositoryBranchName("master");
+            setRepositoryName("mabl-integration-plugin");
+            setRepositoryRevisionNumber("1234");
+            setRepositoryPreviousRevisionNumber("1233");
+            setRepositoryUrl("git@github.com:fakeOrg/mabl-integration-plugin.git");
+        }
+    };
+
+    static final CreateDeploymentProperties GIT_BUILD_PROPS_HTTPS = new CreateDeploymentProperties() {
+        {
+            setBuildPlanId("MyFakeJobName");
+            setBuildPlanName("MyFakeJobName");
+            setBuildPlanNumber("6");
+            setBuildPlanResultUrl("http://server/job/FakeJobName/6/display/redirect");
+            setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+            setRepositoryBranchName("master");
+            setRepositoryName("mabl-integration-plugin");
+            setRepositoryRevisionNumber("1234");
+            setRepositoryPreviousRevisionNumber("1233");
+            setRepositoryUrl("https://github.com/fakeOrg/mabl-integration-plugin.git");
+        }
+    };
+
+    static final CreateDeploymentProperties SVN_BUILD_PROPS = new CreateDeploymentProperties() {
+        {
+            setBuildPlanId("MyFakeJobName");
+            setBuildPlanName("MyFakeJobName");
+            setBuildPlanNumber("6");
+            setBuildPlanResultUrl("http://server/job/FakeJobName/6/display/redirect");
+            setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+            setRepositoryName("int_test_svn");
+            setRepositoryRevisionNumber("12");
+            setRepositoryUrl("https://svn.fakeDomain.com/int_test_svn");
+        }
+    };
 }


### PR DESCRIPTION
Supply build and repository details as properties to mabl deployments. Here is an example output using subversion as the repository:

```
{
  "properties": {
    "build_plan_result_url": {
      "stringValue": "http://127.0.0.1:9090/job/Subversion/5/display/redirect"
    },
    "deployment_origin": {
      "stringValue": "mabl-jenkins-plugin/0.0.10-SNAPSHOT"
    },
    "repository_name": {
      "stringValue": "int_test_svn"
    },
    "build_plan_id": {
      "stringValue": "Subversion"
    },
    "repository_url": {
      "stringValue": "https://svn.riouxsvn.com/int_test_svn"
    },
    "repository_revision_number": {
      "stringValue": "6"
    },
    "build_plan_number": {
      "stringValue": "5"
    },
    "build_plan_name": {
      "stringValue": "Subversion"
    }
  }
}
```