### PR TITLE
Adding links back to mabl tests

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
@@ -16,6 +16,7 @@ public class MablStepConstants {
     static final String PLUGIN_VERSION_UNKNOWN = "unknown";
     static final String PLUGIN_USER_AGENT = "mabl-jenkins-plugin/" + PLUGIN_VERSION;
     static final String TEST_OUTPUT_XML_FILENAME = "report.xml";
+    public static final String TEST_OUTPUT_XML_XLINK = "http://www.w3.org/1999/xlink";
 
     // Label for build steps drop down list
     static final String BUILD_STEP_DISPLAY_NAME = "Run mabl journeys";

--- a/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
@@ -21,7 +21,6 @@ public class MablStepConstants {
     // Label for build steps drop down list
     static final String BUILD_STEP_DISPLAY_NAME = "Run mabl journeys";
     static final String MABL_REST_API_BASE_URL = "https://api.mabl.com";
-    static final String MABL_WEBAPP_BASE_URL = "https://app.mabl.com";
     static final int EXECUTION_TIMEOUT_SECONDS = 3600;
     static final int REQUEST_TIMEOUT_MILLISECONDS = 60000;
     static final long EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS = 10000;

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -188,7 +188,8 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
                 TestCase testCase = new TestCase(
                         safePlanName(summary),
                         safeJourneyName(summary, journeyResult.id),
-                        getDuration(summary)
+                        getDuration(summary),
+                        journeyResult.appHref
                 );
 
                 testSuite.addToTestCases(testCase).incrementTests();

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
@@ -16,6 +16,10 @@ public class TestCase {
     private String journey;
     @XmlAttribute(name = "time")
     private long duration;
+    @XmlAttribute(name = "xlink:type")
+    private String linkType;
+    @XmlAttribute(name = "xlink:href")
+    private String appHref;
 
     @XmlElement(name = "failure")
     private Failure failure;
@@ -24,16 +28,20 @@ public class TestCase {
 
     }
 
-    public TestCase(String plan, String journey, long duration) {
+    public TestCase(String plan, String journey, long duration, String appHref) {
         this.plan = plan;
         this.journey = journey;
         this.duration = duration;
+        this.linkType = "simple";
+        this.appHref = appHref;
     }
 
-    public TestCase(String plan, String journey, long duration, Failure failure) {
+    public TestCase(String plan, String journey, long duration, String appHref, Failure failure) {
         this.plan = plan;
         this.journey = journey;
         this.duration = duration;
+        this.linkType = "simple";
+        this.appHref = appHref;
         this.failure = failure;
     }
 
@@ -52,6 +60,14 @@ public class TestCase {
 
     public long getDuration() {
         return this.duration;
+    }
+
+    public String getAppHref() {
+        return this.appHref;
+    }
+
+    public String getLinkType() {
+        return this.linkType;
     }
 
     public Failure getFailure() {

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
@@ -27,4 +27,12 @@ public class TestSuites {
     public TestSuites() {
 
     }
+
+    public String getXlink() {
+        return xlink;
+    }
+
+    public ImmutableCollection<TestSuite> getTestSuites() {
+        return testSuites;
+    }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestSuites.java
@@ -1,9 +1,11 @@
 package com.mabl.integration.jenkins.test.output;
 
 import com.google.common.collect.ImmutableCollection;
+import com.mabl.integration.jenkins.MablStepConstants;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -11,11 +13,15 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TestSuites {
 
+    @XmlAttribute(name = "xmlns:xlink")
+    private String xlink;
+
     @XmlElement(name = "testsuite")
     private ImmutableCollection<TestSuite> testSuites;
 
     public TestSuites(ImmutableCollection<TestSuite> testSuites) {
         this.testSuites = testSuites;
+        this.xlink = MablStepConstants.TEST_OUTPUT_XML_XLINK;
     }
 
     public TestSuites() {

--- a/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablTestConstants.java
@@ -145,17 +145,17 @@ class MablTestConstants {
 
     static final String TEST_CASE_XML = "" +
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\"/>";
+            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\" xlink:type=\"simple\" xlink:href=\"http://myapphref.com\"/>";
 
     static final String TEST_CASE_XML_WITH_FAILURE = "" +
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\">" +
+            "<testcase classname=\"My Plan Name\" name=\"My Journey Name\" time=\"23\" xlink:type=\"simple\" xlink:href=\"http://myapphref.com\">" +
                 "<failure message=\"My Message\">My Reason</failure>" +
             "</testcase>";
 
     static final String TEST_SUITES_XML = "" +
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-            "<testsuites>" +
+            "<testsuites xmlns:xlink=\"http://www.w3.org/1999/xlink\">" +
                 "<testsuite name=\"Empty Test Suite\" tests=\"0\" errors=\"0\" failures=\"0\" time=\"0\" timestamp=\"2013-05-24T10:23:58\">" +
                     "<properties/>" +
                 "</testsuite>" +
@@ -164,8 +164,8 @@ class MablTestConstants {
                         "<property name=\"environment\" value=\"my env-e\"/>" +
                         "<property name=\"application\" value=\"my app-a\"/>" +
                     "</properties>" +
-                    "<testcase classname=\"My Plan Name 1\" name=\"My Journey Name 1\" time=\"11\"/>" +
-                    "<testcase classname=\"My Plan Name 2\" name=\"My Journey Name 2\" time=\"22\">" +
+                    "<testcase classname=\"My Plan Name 1\" name=\"My Journey Name 1\" time=\"11\" xlink:type=\"simple\" xlink:href=\"http://myapphref.com\"/>" +
+                    "<testcase classname=\"My Plan Name 2\" name=\"My Journey Name 2\" time=\"22\" xlink:type=\"simple\" xlink:href=\"http://myapphref.com\">" +
                         "<failure message=\"My Message\">My Reason</failure>" +
                     "</testcase>" +
                 "</testsuite>" +

--- a/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
+++ b/src/test/java/com/mabl/integration/jenkins/TestOutputTests.java
@@ -21,7 +21,7 @@ public class TestOutputTests {
 
     @Test
     public void testTestCaseOutputNoFailure() throws JAXBException {
-        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L);
+        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L, "http://myapphref.com");
         JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
         Marshaller marshaller = jaxbContext.createMarshaller();
         StringWriter stringWriter = new StringWriter();
@@ -32,7 +32,7 @@ public class TestOutputTests {
     @Test
     public void testTestCaseOutputWithFailure() throws JAXBException {
         Failure failure = new Failure("My Reason", "My Message");
-        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L, failure);
+        TestCase testCase = new TestCase("My Plan Name", "My Journey Name", 23L, "http://myapphref.com", failure);
         JAXBContext jaxbContext = JAXBContext.newInstance(TestCase.class);
         Marshaller marshaller = jaxbContext.createMarshaller();
         StringWriter stringWriter = new StringWriter();
@@ -56,9 +56,9 @@ public class TestOutputTests {
         props.add(property2);
         Properties properties = new Properties(ImmutableList.copyOf(props));
 
-        TestCase testCase1 = new TestCase("My Plan Name 1", "My Journey Name 1", 11L);
+        TestCase testCase1 = new TestCase("My Plan Name 1", "My Journey Name 1", 11L, "http://myapphref.com");
         Failure failure = new Failure("My Reason", "My Message");
-        TestCase testCase2 = new TestCase("My Plan Name 2", "My Journey Name 2", 22L, failure);
+        TestCase testCase2 = new TestCase("My Plan Name 2", "My Journey Name 2", 22L, "http://myapphref.com", failure);
         TestSuite testSuite1 = new TestSuite(
                 "Full Test Suite",
                 33L,


### PR DESCRIPTION
Added the link on the test case back to the mabl test in question. However, it's up to the individual report plugins if this link is shown everywhere. To complete this fully, we'll probably have to provide our own test report output reader that happens all the time if the mabl plugin is installed.

Here is an example of the new XML.

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<testsuites xmlns:xlink="http://www.w3.org/1999/xlink">
    <testsuite name="Prod Verify" tests="2" errors="0" failures="0" time="80" timestamp="2018-06-13T16:01:42">
        <testcase classname="Prod Verify" name="Login" time="80" xlink:type="simple" xlink:href="https://app.mabl.com/workspaces/40w-kuu1iL4zPHHqZw1Nog-w/train/journeys/RbPR1FYzDKvJmobbsMfdXQ-j:0"/>
        <testcase classname="Prod Verify" name="Visit home page" time="80" xlink:type="simple" xlink:href="https://app.mabl.com/workspaces/40w-kuu1iL4zPHHqZw1Nog-w/train/journeys/sNF-e1AIw3d_OGt40jdO5w-j:0"/>
    </testsuite>
</testsuites>
```