### PR TITLE
Add disableSslVerification flag

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -107,6 +107,10 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
         return this.continueOnMablError;
     }
 
+    public boolean isDisableSslVerification() {
+        return this.disableSslVerification;
+    }
+
     @Override
     public void perform(
             @Nonnull final Run<?, ?> run,

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -54,6 +54,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     private final String applicationId;
     private boolean continueOnPlanFailure;
     private boolean continueOnMablError;
+    private boolean disableSslVerification;
 
     @DataBoundConstructor
     public MablStepBuilder(
@@ -74,6 +75,11 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     @DataBoundSetter
     public void setContinueOnMablError(boolean continueOnMablError) {
         this.continueOnMablError = continueOnMablError;
+    }
+    
+    @DataBoundSetter
+    public void setDisableSslVerification(boolean disableSslVerification) {
+        this.disableSslVerification = disableSslVerification;
     }
 
     // Accessors to be used by Jelly UI templates
@@ -110,7 +116,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     ) throws InterruptedException {
 
         final PrintStream outputStream = listener.getLogger();
-        final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, restApiKey);
+        final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, restApiKey, disableSslVerification);
 
         final MablStepDeploymentRunner runner = new MablStepDeploymentRunner(
                 client,
@@ -230,7 +236,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return MablStepBuilderValidator.validateForm(restApiKey, environmentId, applicationId);
         }
 
-        public ListBoxModel doFillApplicationIdItems(@QueryParameter String restApiKey) {
+        public ListBoxModel doFillApplicationIdItems(@QueryParameter String restApiKey, @QueryParameter boolean disableSslVerification) {
             if(restApiKey == null || restApiKey.isEmpty()) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("Input an Api Key", "");
@@ -238,11 +244,11 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
                 return items;
             }
 
-            return getApplicationIdItems(restApiKey);
+            return getApplicationIdItems(restApiKey, disableSslVerification);
         }
 
-        private ListBoxModel getApplicationIdItems(String formApiKey) {
-            final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey);
+        private ListBoxModel getApplicationIdItems(String formApiKey, boolean disableSslVerification) {
+            final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey, disableSslVerification);
             ListBoxModel items = new ListBoxModel();
             try {
                 GetApiKeyResult apiKeyResult = client.getApiKeyResult(formApiKey);
@@ -263,7 +269,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return items;
         }
 
-        public ListBoxModel doFillEnvironmentIdItems(@QueryParameter String restApiKey) {
+        public ListBoxModel doFillEnvironmentIdItems(@QueryParameter String restApiKey, @QueryParameter boolean disableSslVerification) {
             if(restApiKey == null || restApiKey.isEmpty()) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("Input an Api Key", "");
@@ -271,11 +277,11 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
                 return items;
             }
 
-            return getEnvironmentIdItems(restApiKey);
+            return getEnvironmentIdItems(restApiKey, disableSslVerification);
         }
 
-        private ListBoxModel getEnvironmentIdItems(String formApiKey) {
-            final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey);
+        private ListBoxModel getEnvironmentIdItems(String formApiKey, boolean disableSslVerification) {
+            final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey, disableSslVerification);
             ListBoxModel items = new ListBoxModel();
             try {
                 GetApiKeyResult apiKeyResult = client.getApiKeyResult(formApiKey);

--- a/src/main/java/com/mabl/integration/jenkins/domain/GetEnvironmentsResult.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/GetEnvironmentsResult.java
@@ -10,9 +10,9 @@ public class GetEnvironmentsResult implements ApiResult {
 
     @JsonCreator
     public GetEnvironmentsResult(
-            @JsonProperty("environments") final List<Environment> applications
+            @JsonProperty("environments") final List<Environment> environments
     ) {
-        this.environments = applications;
+        this.environments = environments;
     }
 
     @SuppressWarnings("WeakerAccess")

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
@@ -24,5 +24,8 @@
     <f:entry title="${%Continue on mabl API failure}" field="continueOnMablError">
       <f:checkbox default="false" />
     </f:entry>
+    <f:entry title="${%Disable SSL verification}" field="disableSslVerification">
+      <f:checkbox default="false" />
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-disableSslVerification.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-disableSslVerification.html
@@ -1,0 +1,3 @@
+<div>
+    disable SSL verification (only required if Jenkins is behind a MITM proxy)
+</div>


### PR DESCRIPTION
A user reached out recently about an issue with the plugin.  Apparently their Jenkins instance is behind a man-in-the-middle proxy that is intercepting the SSL traffic between the plugin and mabl, and that's causing the SSL verification to fail, so the plugin can't talk to the mabl APIs.  This change adds a plugin flag which will disable SSL verification, which isn't ideal, but it's probably the easiest work-around.

This is my first time doing any Jenkins plugin development, so I'm not sure if I missed anything.  I also haven't tested this out in a real Jenkins instance yet.  Just wanted to get some feedback about whether I'm on the right track.