### PR TITLE
Upgrade Jackson to 2.6.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.11-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.3</version>
+            <version>2.6.7.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/mabl/integration/jenkins/JenkinsModule.java
+++ b/src/main/java/com/mabl/integration/jenkins/JenkinsModule.java
@@ -5,8 +5,8 @@ import com.google.inject.Provides;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 public class JenkinsModule extends AbstractModule {
@@ -16,19 +16,17 @@ public class JenkinsModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        FileInputStream inputStream = null;
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
         try {
             Properties properties = new Properties();
-            properties.load(getClass().getClassLoader().getResourceAsStream(CONFIG_FILE));
+            properties.load(inputStream);
             Names.bindProperties(binder(), properties);
         } catch (IOException e) {
             System.out.println("ERROR: Could not load properties");
             throw new RuntimeException(e);
         } finally {
             try {
-                if(inputStream != null) {
-                    inputStream.close();
-                }
+                inputStream.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/com/mabl/integration/jenkins/AbstractWiremockTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/AbstractWiremockTest.java
@@ -5,41 +5,31 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
-import com.mabl.integration.jenkins.domain.CreateDeploymentResult;
-import com.mabl.integration.jenkins.domain.ExecutionResult;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.junit.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.created;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.mabl.integration.jenkins.MablRestApiClientImpl.DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE;
-import static com.mabl.integration.jenkins.MablRestApiClientImpl.REST_API_USERNAME_PLACEHOLDER;
 import static com.mabl.integration.jenkins.MablStepConstants.PLUGIN_USER_AGENT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Common Wiremock testing harness
  */
 public abstract class AbstractWiremockTest {
+    private static final int BIND_PORT = 0; // Choose a random available port each time
 
     // Annotation used only for static rules, so we only startup a single Wiremock instance
     @ClassRule
-    public static WireMockClassRule wireMockRule = new WireMockClassRule();
+    public static WireMockClassRule wireMockRule = new WireMockClassRule(BIND_PORT);
 
     // Pass the above instance to all concrete implementations
     @Rule
@@ -140,7 +130,7 @@ public abstract class AbstractWiremockTest {
     }
 
     protected String getBaseUrl() {
-        final int portNumber = wireMockRule.getOptions().portNumber();
+        final int portNumber = wireMockRule.port();
         final String address = wireMockRule.getOptions().bindAddress();
         return String.format("http://%s:%d", address, portNumber);
     }


### PR DESCRIPTION
Upgrade Jackson to 2.6.7.1 to fix a security vulnerability that our scanner identified.

Also fixes a couple other minor issues I noticed while upgrading Jackson
* Unit tests should use random ports to avoid port conflicts
* We were not properly cleaning up an input stream related to reading the plugin configuration file (FindBugs flagged this one)