### PR TITLE
Address NullPointerException when result status is null.

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -1,5 +1,6 @@
 package com.mabl.integration.jenkins;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
@@ -242,13 +243,21 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         for (ExecutionResult.ExecutionSummary summary : result.executions) {
             outputStream.printf("  Plan [%s] is [%s]%n", safePlanName(summary), summary.status);
             for (ExecutionResult.JourneyExecutionResult journeyResult : summary.journeyExecutions) {
-                String journeyFormat = String.format("    Journey [%s] is [%s]", safeJourneyName(summary, journeyResult.id), journeyResult.status);
-                if (journeyResult.status.equalsIgnoreCase("failed")) {
-                    outputStream.printf(journeyFormat + " at [%s]%n", journeyResult.appHref);
-                } else {
-                    outputStream.println(journeyFormat);
-                }
+                String logSummary = String.format("    Journey [%s] is %s",
+                    safeJourneyName(summary, journeyResult.id),
+                    executionResultToString(journeyResult));
+                outputStream.println(logSummary);
             }
+        }
+    }
+
+    static String executionResultToString(ExecutionResult.JourneyExecutionResult journeyResult) {
+        String cleanStatus = Optional.fromNullable(journeyResult.status).or("waiting");
+        String journeyFormat = String.format("[%s]", cleanStatus);
+        if (cleanStatus.equalsIgnoreCase("failed")) {
+            return String.format(journeyFormat + " at [%s]",journeyResult.appHref);
+        } else {
+            return journeyFormat;
         }
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -1,6 +1,5 @@
 package com.mabl.integration.jenkins;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.mabl.integration.jenkins.domain.CreateDeploymentProperties;
@@ -252,7 +251,7 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     }
 
     static String executionResultToString(ExecutionResult.JourneyExecutionResult journeyResult) {
-        String cleanStatus = Optional.fromNullable(journeyResult.status).or("waiting");
+        String cleanStatus = journeyResult.status != null ? journeyResult.status : "waiting";
         String journeyFormat = String.format("[%s]", cleanStatus);
         if (cleanStatus.equalsIgnoreCase("failed")) {
             return String.format(journeyFormat + " at [%s]",journeyResult.appHref);

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -15,13 +15,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -186,6 +185,48 @@ public class MablStepDeploymentRunnerTest {
         assertTrue("failure override expected", runner.call());
 
         verify(client).close();
+    }
+
+    @Test
+    public void executionResultToString_undefinedStatus_isWaiting() {
+        ExecutionResult.JourneyExecutionResult result = new ExecutionResult.JourneyExecutionResult(
+            null,
+            null,
+            null,
+            null,
+            null, // <-- status is null
+            null,
+            false);
+
+        assertEquals("[waiting]", MablStepDeploymentRunner.executionResultToString(result));
+    }
+
+    @Test
+    public void executionResultToString_failed_showsURL() {
+        ExecutionResult.JourneyExecutionResult result = new ExecutionResult.JourneyExecutionResult(
+            null,
+            null,
+            null,
+            "http://appUrl",
+            "failed",
+            null,
+            false);
+
+        assertEquals("[failed] at [http://appUrl]", MablStepDeploymentRunner.executionResultToString(result));
+    }
+
+    @Test
+    public void executionResultToString_completed_showsCompleted() {
+        ExecutionResult.JourneyExecutionResult result = new ExecutionResult.JourneyExecutionResult(
+            null,
+            null,
+            null,
+            null,
+            "completed",
+            null,
+            false);
+
+        assertEquals("[completed]", MablStepDeploymentRunner.executionResultToString(result));
     }
 
     private ExecutionResult createExecutionResult(


### PR DESCRIPTION
Jenkins console output before: 
```
Running mabl journey(s) status update:
  Plan [Multistep plan] is [scheduled]
Unexpected mabl-integration-plugin exception
java.lang.NullPointerException
	at com.mabl.integration.jenkins.MablStepDeploymentRunner.printAllJourneyExecutionStatuses(MablStepDeploymentRunner.java:246)
	at com.mabl.integration.jenkins.MablStepDeploymentRunner.execute(MablStepDeploymentRunner.java:146)
	at com.mabl.integration.jenkins.MablStepDeploymentRunner.call(MablStepDeploymentRunner.java:98)
	at com.mabl.integration.jenkins.MablStepDeploymentRunner.call(MablStepDeploymentRunner.java:42)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
mabl journey execution step complete.

```

After:
```
Running mabl journey(s) status update:
  Plan [Multistep plan] is [scheduled]
    Journey [Take a little break] is [queued]
    Journey [Take a little break] is [waiting]
    Journey [Take a little break] is [waiting]
    Journey [Take a little break] is [completed]
```