### PR TITLE
Hacktoberfest - Migrating doc page from Wiki to Github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
-    <url>http://github.com/jenkinsci/mabl-integration-plugin</url>
+    <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
 
     <properties>
         <!-- Last Jenkins LTS release -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
-    <url>https://wiki.jenkins.io/display/JENKINS/mabl+Integration</url>
+    <url>http://github.com/jenkinsci/mabl-integration-plugin</url>
 
     <properties>
         <!-- Last Jenkins LTS release -->


### PR DESCRIPTION
Following the recommendation(https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Referencingthedocumentationpagefromtheprojectfile) the project url was updated to point to Github.