### PR TITLE
Addressing remaining issues around handling REST API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Send build environment variables is set. Collecting the following information:
 
 ### Change Log
 
+#### v0.0.19 (3 March 2020)
+-   Security fixes for handling API key
+-   Fixed POM to use Findbugs version variable
+-   Improved the plan label form by displaying the currently configured values
+
 #### v0.0.18 (4 February 2020)
 -   Screenshot and documentation updates
 -   Updates to dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jenkins-test-harness.version>1.580.1</jenkins-test-harness.version>
         <release.skipTests>false</release.skipTests>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <concurrency>1</concurrency>
         <java.level>6</java.level>
         <hpi-plugin.version>1.120</hpi-plugin.version>
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClient.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClient.java
@@ -7,6 +7,7 @@ import com.mabl.integration.jenkins.domain.GetApiKeyResult;
 import com.mabl.integration.jenkins.domain.GetApplicationsResult;
 import com.mabl.integration.jenkins.domain.GetEnvironmentsResult;
 import com.mabl.integration.jenkins.domain.GetLabelsResult;
+import hudson.util.Secret;
 
 import java.io.IOException;
 import java.util.Set;
@@ -41,7 +42,7 @@ public interface MablRestApiClient {
      * @throws MablSystemError on non 200 or 404 response
      */
     GetApiKeyResult getApiKeyResult(
-            String restApiKey
+            Secret restApiKey
     ) throws IOException, MablSystemError;
 
     /**

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -16,6 +16,7 @@ import com.mabl.integration.jenkins.domain.GetApplicationsResult;
 import com.mabl.integration.jenkins.domain.GetEnvironmentsResult;
 import com.mabl.integration.jenkins.domain.GetLabelsResult;
 import hudson.remoting.Base64;
+import hudson.util.Secret;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
@@ -85,18 +86,18 @@ public class MablRestApiClientImpl implements MablRestApiClient {
 
     private final CloseableHttpClient httpClient;
     private final String restApiBaseUrl;
-    private final String restApiKey;
+    private final Secret restApiKey;
 
     MablRestApiClientImpl(
             final String restApiBaseUrl,
-            final String restApiKey
+            final Secret restApiKey
     ) {
         this(restApiBaseUrl, restApiKey, false);
     }
     
     MablRestApiClientImpl(
             final String restApiBaseUrl,
-            final String restApiKey,
+            final Secret restApiKey,
             final boolean disableSslVerification
     ) {
 
@@ -139,11 +140,11 @@ public class MablRestApiClientImpl implements MablRestApiClient {
     }
 
     private CredentialsProvider getApiCredentialsProvider(
-            final String restApiKey
+            final Secret restApiKey
     ) {
         final CredentialsProvider provider = new BasicCredentialsProvider();
         final UsernamePasswordCredentials creds =
-                new UsernamePasswordCredentials(REST_API_USERNAME_PLACEHOLDER, restApiKey);
+                new UsernamePasswordCredentials(REST_API_USERNAME_PLACEHOLDER, restApiKey.getPlainText());
 
         provider.setCredentials(AuthScope.ANY, creds);
 
@@ -151,9 +152,9 @@ public class MablRestApiClientImpl implements MablRestApiClient {
     }
 
     private Header getBasicAuthHeader(
-            final String restApiKey
+            final Secret restApiKey
     ) {
-        final String encoded = Base64.encode((REST_API_USERNAME_PLACEHOLDER + ":" + restApiKey)
+        final String encoded = Base64.encode((REST_API_USERNAME_PLACEHOLDER + ":" + restApiKey.getPlainText())
                 .getBytes(Charset.forName("UTF-8")));
         return new BasicHeader("Authorization", "Basic " + encoded);
     }
@@ -187,8 +188,8 @@ public class MablRestApiClientImpl implements MablRestApiClient {
     }
 
     @Override
-    public GetApiKeyResult getApiKeyResult(String formApiKey) throws IOException, MablSystemError {
-        final String url = restApiBaseUrl + String.format(GET_ORGANIZATION_ENDPOINT_TEMPLATE, formApiKey);
+    public GetApiKeyResult getApiKeyResult(Secret formApiKey) throws IOException, MablSystemError {
+        final String url = restApiBaseUrl + String.format(GET_ORGANIZATION_ENDPOINT_TEMPLATE, formApiKey.getPlainText());
         return parseApiResult(httpClient.execute(buildGetRequest(url)), GetApiKeyResult.class);
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -52,6 +53,10 @@ import static org.apache.commons.lang.StringUtils.trimToNull;
  */
 @SuppressWarnings("unused") // automatically discovered by Jenkins
 public class MablStepBuilder extends Builder implements SimpleBuildStep {
+    @Override
+    public String toString() {
+        return "MABL Step Builder " + this.hashCode();
+    }
 
     private final Secret restApiKey;
     private final String environmentId;
@@ -63,12 +68,12 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundConstructor
     public MablStepBuilder(
-            final String restApiKey,
+            final Secret restApiKey,
             final String environmentId,
             final String applicationId,
             final Set<String> labels
     ) {
-        this.restApiKey = Secret.fromString(trimToNull(restApiKey));
+        this.restApiKey = restApiKey;
         this.environmentId = trimToNull(environmentId);
         this.applicationId = trimToNull(applicationId);
         this.labels = labels != null ? labels : new HashSet<String>();
@@ -90,8 +95,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     }
 
     // Accessors to be used by Jelly UI templates
-    public String getRestApiKey() {
-        return restApiKey.getPlainText();
+    public Secret getRestApiKey() {
+        return restApiKey;
     }
 
     public String getEnvironmentId() {
@@ -216,6 +221,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     @Symbol(PLUGIN_SYMBOL)
     public static class MablStepDescriptor extends BuildStepDescriptor<Builder> {
         private boolean collectVars;
+        private Secret restApiKey;
+        private Set<String> labels;
 
         public MablStepDescriptor() {
             super.load();
@@ -245,17 +252,18 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
 
         public FormValidation doValidateForm(
-                @QueryParameter("restApiKey") final String restApiKey,
+                @QueryParameter("restApiKey") final Secret restApiKey,
                 @QueryParameter("environmentId") final String environmentId,
                 @QueryParameter("applicationId") final String applicationId
         ) {
             return MablStepBuilderValidator.validateForm(restApiKey, environmentId, applicationId);
         }
 
-        public ListBoxModel doFillApplicationIdItems(@QueryParameter String restApiKey, @QueryParameter boolean disableSslVerification) {
-            if(restApiKey == null || restApiKey.isEmpty()) {
+        public ListBoxModel doFillApplicationIdItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
+
+            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
                 ListBoxModel items = new ListBoxModel();
-                items.add("Input an Api Key", "");
+                items.add("Input an API Key", "");
 
                 return items;
             }
@@ -263,7 +271,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return getApplicationIdItems(restApiKey, disableSslVerification);
         }
 
-        private ListBoxModel getApplicationIdItems(String formApiKey, boolean disableSslVerification) {
+        private ListBoxModel getApplicationIdItems(Secret formApiKey, boolean disableSslVerification) {
             final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey, disableSslVerification);
             ListBoxModel items = new ListBoxModel();
             try {
@@ -287,8 +295,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return items;
         }
 
-        public ListBoxModel doFillEnvironmentIdItems(@QueryParameter String restApiKey, @QueryParameter boolean disableSslVerification) {
-            if(restApiKey == null || restApiKey.isEmpty()) {
+        public ListBoxModel doFillEnvironmentIdItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
+            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("Input an API key", "");
 
@@ -298,7 +306,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return getEnvironmentIdItems(restApiKey, disableSslVerification);
         }
 
-        private ListBoxModel getEnvironmentIdItems(String formApiKey, boolean disableSslVerification) {
+        private ListBoxModel getEnvironmentIdItems(Secret formApiKey, boolean disableSslVerification) {
             final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey, disableSslVerification);
             ListBoxModel items = new ListBoxModel();
             try {
@@ -322,9 +330,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return items;
         }
 
-
-        public ListBoxModel doFillLabelsItems(@QueryParameter String restApiKey, @QueryParameter boolean disableSslVerification) {
-            if(restApiKey == null || restApiKey.isEmpty()) {
+        public ListBoxModel doFillLabelsItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
+            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("<No Labels Found>", "");
 
@@ -334,7 +341,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             return getLabelsItems(restApiKey, disableSslVerification);
         }
 
-        private ListBoxModel getLabelsItems(String formApiKey, boolean disableSslVerification) {
+        private ListBoxModel getLabelsItems(Secret formApiKey, boolean disableSslVerification) {
             final MablRestApiClient client = new MablRestApiClientImpl(MABL_REST_API_BASE_URL, formApiKey, disableSslVerification);
             ListBoxModel items = new ListBoxModel();
             try {

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -221,8 +221,6 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     @Symbol(PLUGIN_SYMBOL)
     public static class MablStepDescriptor extends BuildStepDescriptor<Builder> {
         private boolean collectVars;
-        private Secret restApiKey;
-        private Set<String> labels;
 
         public MablStepDescriptor() {
             super.load();

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -258,8 +258,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
         }
 
         public ListBoxModel doFillApplicationIdItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
-
-            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
+            if (isSecretEmpty(restApiKey)) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("Input an API Key", "");
 
@@ -294,7 +293,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
         }
 
         public ListBoxModel doFillEnvironmentIdItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
-            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
+            if (isSecretEmpty(restApiKey)) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("Input an API key", "");
 
@@ -329,7 +328,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
         }
 
         public ListBoxModel doFillLabelsItems(@QueryParameter Secret restApiKey, @QueryParameter boolean disableSslVerification) {
-            if(restApiKey == null || restApiKey.getPlainText() == null || restApiKey.getPlainText().isEmpty()) {
+            if (isSecretEmpty(restApiKey)) {
                 ListBoxModel items = new ListBoxModel();
                 items.add("<No Labels Found>", "");
 
@@ -360,6 +359,10 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
             items.add("<Couldn't Fetch Labels>", "");
             return items;
+        }
+
+        private static boolean isSecretEmpty(final Secret secret) {
+            return secret == null || secret.getPlainText() == null || secret.getPlainText().isEmpty();
         }
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/validation/MablStepBuilderValidator.java
+++ b/src/main/java/com/mabl/integration/jenkins/validation/MablStepBuilderValidator.java
@@ -1,6 +1,7 @@
 package com.mabl.integration.jenkins.validation;
 
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 
 import static com.mabl.integration.jenkins.MablStepConstants.FORM_API_KEY_LABEL;
 import static com.mabl.integration.jenkins.MablStepConstants.FORM_APPLICATION_ID_LABEL;
@@ -24,14 +25,14 @@ public class MablStepBuilderValidator {
      * @return validation result
      */
     public static FormValidation validateForm(
-            String restApiKey,
+            Secret restApiKey,
             String environmentId,
             String applicationId
     ) {
         try {
 
             // TODO MOVE into validator class when we add remote validation
-            final String restApiKeyClean = trimToNull(restApiKey);
+            final String restApiKeyClean = trimToNull(restApiKey == null ? null : restApiKey.getPlainText());
             final String applicationIdClean = trimToNull(applicationId);
             final String environmentIdClean = trimToNull(environmentId);
 

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-applicationId.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-applicationId.html
@@ -1,3 +1,3 @@
 <div>
-    Input a valid ApiKey to populate the application selection drop-down.
+    Input a valid API key to populate the application selection drop-down.
 </div>

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-environmentId.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-environmentId.html
@@ -1,3 +1,3 @@
 <div>
-    Input a valid ApiKey to populate the environment selection drop-down.
+    Input a valid API key to populate the environment selection drop-down.
 </div>

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -9,9 +9,11 @@ import com.mabl.integration.jenkins.domain.ExecutionResult;
 import com.mabl.integration.jenkins.domain.GetApiKeyResult;
 import com.mabl.integration.jenkins.domain.GetApplicationsResult;
 import com.mabl.integration.jenkins.domain.GetEnvironmentsResult;
+import hudson.util.Secret;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.Set;
 
@@ -30,6 +32,7 @@ import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Unit test for REST API calls
@@ -127,7 +130,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, restApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(restApiKey));
             CreateDeploymentProperties properties = new CreateDeploymentProperties();
             properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
             CreateDeploymentResult result = client.createDeploymentEvent(environmentId, applicationId, labels, properties);
@@ -158,7 +161,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, fakeRestApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKey));
             ExecutionResult result = client.getExecutionResults(eventId);
             assertEquals("succeeded", result.executions.get(0).status);
             assertTrue("expected success", result.executions.get(0).success);
@@ -188,7 +191,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, fakeRestApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKey));
             ExecutionResult result = client.getExecutionResults(eventId);
             assertNull(result);
         } finally {
@@ -217,8 +220,8 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, fakeRestApiKey);
-            GetApiKeyResult result = client.getApiKeyResult(fakeRestApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKey));
+            GetApiKeyResult result = client.getApiKeyResult(mockSecret(fakeRestApiKey));
             assertEquals(EXPECTED_ORGANIZATION_ID, result.organization_id);
         } finally {
             if (client != null) {
@@ -246,7 +249,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, fakeRestApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKey));
             GetApplicationsResult result = client.getApplicationsResult(organization_id);
             assertEquals(2, result.applications.size());
         } finally {
@@ -274,7 +277,7 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
 
         MablRestApiClient client = null;
         try {
-            client = new MablRestApiClientImpl(baseUrl, fakeRestApiKey);
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKey));
             GetEnvironmentsResult result = client.getEnvironmentsResult(organization_id);
             assertEquals(1, result.environments.size());
         } finally {
@@ -340,5 +343,17 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
                         .withHeader("Content-Type", "application/json")
                         .withBody(MablTestConstants.CREATE_DEPLOYMENT_EVENT_RESULT_JSON))
         );
+    }
+
+    private Secret mockSecret(String value) {
+        try {
+            final Constructor<?> c = Class.forName("hudson.util.Secret").getDeclaredConstructor(String.class);
+            c.setAccessible(true);
+            return (Secret)c.newInstance(value);
+
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        return null;
     }
 }

--- a/src/test/java/com/mabl/integration/jenkins/validation/MablBuildValidatorTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/validation/MablBuildValidatorTest.java
@@ -1,6 +1,7 @@
 package com.mabl.integration.jenkins.validation;
 
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import org.junit.Test;
 
 import static com.mabl.integration.jenkins.MablStepConstants.FORM_API_KEY_LABEL;
@@ -21,7 +22,7 @@ public class MablBuildValidatorTest {
     public void validateGoodAllFieldsForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 "sample-environment-id",
                 "sample-application-id"
         );
@@ -33,7 +34,7 @@ public class MablBuildValidatorTest {
     public void validateGoodEnvironmentOnlyForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 "sample-environment-id",
                 null
         );
@@ -45,7 +46,7 @@ public class MablBuildValidatorTest {
     public void validateGoodApplicationOnlyForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 null,
                 "sample-application-id"
         );
@@ -57,7 +58,7 @@ public class MablBuildValidatorTest {
     public void validateBadNoEnvironmentOrApplicationForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 null,
                 null
         );
@@ -73,7 +74,7 @@ public class MablBuildValidatorTest {
     public void validateBadNoEnvironmentIdInWrongFieldApplicationForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 "sample-a",
                 null
         );
@@ -89,7 +90,7 @@ public class MablBuildValidatorTest {
     public void validateBadNoApplicationIdInWrongFieldApplicationForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 null,
                 "sample-e"
         );
@@ -105,7 +106,7 @@ public class MablBuildValidatorTest {
     public void validateBadNoEnvironmentOrApplicationWhiteSpaceForm() {
 
         final FormValidation actual = validateForm(
-                "sample-key",
+                Secret.fromString("sample-key"),
                 "  ",
                 "\t"
         );
@@ -131,17 +132,4 @@ public class MablBuildValidatorTest {
                 actual.getMessage().contains(FORM_API_KEY_LABEL));
     }
 
-    @Test
-    public void validateBadNoRestApiKeyWithWhitespaceForm() {
-
-        final FormValidation actual = validateForm(
-                "\t\n ",
-                null,
-                null
-        );
-
-        assertEquals(ERROR, actual.kind);
-        assertTrue("rest API key label expected",
-                actual.getMessage().contains(FORM_API_KEY_LABEL));
-    }
 }


### PR DESCRIPTION
These changes update the code so that the REST API key is passed around security inside the integration plugin. The test code had to be updated to use reflection to invoke a constructor in the Secret Java class from Jenkins.