### PR TITLE
Fix for an IllegalArgumentException shown in the Jenkins logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Note that
 
 ### Change Log
 
+#### v0.0.21 (5 June 2020)
+-   Fix for a benign exception visible in the Jenkins logs
+
 #### v0.0.21 (2 June 2020)
 -   Raised minimum version to 2.121.3
 -   Switched to use Secret text credential kind for storing mabl API key

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -37,6 +37,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -71,7 +72,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     private final String restApiKeyId;
     private final String environmentId;
     private final String applicationId;
-    private final Set<String> labels;
+    private Set<String> labels = Collections.emptySet();
     private boolean continueOnPlanFailure;
     private boolean continueOnMablError;
     private boolean disableSslVerification;
@@ -80,13 +81,20 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     public MablStepBuilder(
             final String restApiKeyId,
             final String environmentId,
-            final String applicationId,
-            final Set<String> labels
+            final String applicationId
     ) {
         this.restApiKeyId = restApiKeyId;
         this.environmentId = trimToNull(environmentId);
         this.applicationId = trimToNull(applicationId);
-        this.labels = labels != null ? labels : new HashSet<>();
+    }
+
+    @DataBoundSetter
+    public void setLabels(Collection<String> labels) {
+        if (labels != null && !labels.isEmpty()) {
+            this.labels = new HashSet<>(labels);
+        } else {
+            this.labels = Collections.emptySet();
+        }
     }
 
     @DataBoundSetter


### PR DESCRIPTION
This exception has no side effects apart from looking ugly.

Example exception:
```
2020-06-03 17:17:38.015+0000 [id=72]	WARNING	o.j.p.s.d.DescribableModel#uninstantiate2: Cannot create control version of class org.jenkinsci.plugins.workflow.steps.CoreStep using {delegate=@mabl$MablStepBuilder(applicationId=xxx-a,environmentId=yyy-e,labels=[labelZ],restApiKeyId=restApiKeyId1)}
java.lang.IllegalArgumentException: argument type mismatch
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jenkinsci.plugins.structs.describable.Setter$1.set(Setter.java:33)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.injectSetters(DescribableModel.java:429)
	at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:331)
```