### PR TITLE
Updated Jackson dependencies to 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Note that
 
 ### Change Log
 
+#### v0.0.26 (18 June 2020)
+-   Updated Jackson dependencies to 2.11.0
+
 #### v0.0.25 (15 June 2020)
 -   Adjusted labels in configuration
 -   Set compatibility version

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
     </pluginRepositories>
 
     <dependencies>
-        <!-- 1.14+ breaks dependency limitations for 1.x builds -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
@@ -114,17 +113,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.10</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.10</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This change addresses a security vulnerability present in the current version of Jackson components