### PR TITLE
Fix regression on setting mabl endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Note that
 
 ### Change Log
 
+#### v0.0.31 (08/11/2020)
+-   Fixed a regression related to default endpoints
+
 #### v0.0.30 (08/10/2020)
 -   Updated JUnit report to include information about test case IDs in
     both the properties section of the TestSuite tag as well as in the non-standard

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Note that
 
 ### Change Log
 
-#### v0.0.31 (08/11/2020)
+#### v0.0.31 (08/12/2020)
 -   Fixed a regression related to default endpoints
 
 #### v0.0.30 (08/10/2020)

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -33,6 +33,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -74,8 +75,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     private boolean continueOnPlanFailure;
     private boolean continueOnMablError;
     private boolean disableSslVerification;
-    private String apiBaseUrl = DEFAULT_MABL_API_BASE_URL;
-    private String appBaseUrl = DEFAULT_MABL_APP_BASE_URL;
+    private String apiBaseUrl;
+    private String appBaseUrl;
 
     @DataBoundConstructor
     public MablStepBuilder(
@@ -115,12 +116,12 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setApiBaseUrl(String apiBaseUrl) {
-        this.apiBaseUrl = StringUtils.isEmpty(apiBaseUrl) ? DEFAULT_MABL_API_BASE_URL : apiBaseUrl;
+        this.apiBaseUrl = apiBaseUrl;
     }
 
     @DataBoundSetter
     public void setAppBaseUrl(String appBaseUrl) {
-        this.appBaseUrl = StringUtils.isEmpty(appBaseUrl) ? DEFAULT_MABL_APP_BASE_URL : appBaseUrl;
+        this.appBaseUrl = appBaseUrl;
     }
 
     // Accessors to be used by Jelly UI templates
@@ -172,9 +173,9 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
         final PrintStream outputStream = listener.getLogger();
         final MablRestApiClient client = new MablRestApiClientImpl(
-                apiBaseUrl,
+                StringUtils.isBlank(apiBaseUrl) ? DEFAULT_MABL_API_BASE_URL : apiBaseUrl,
                 getRestApiSecret(getRestApiKeyId()),
-                appBaseUrl,
+                StringUtils.isBlank(appBaseUrl) ? DEFAULT_MABL_APP_BASE_URL : appBaseUrl,
                 disableSslVerification
         );
 

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -115,12 +115,12 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setApiBaseUrl(String apiBaseUrl) {
-        this.apiBaseUrl = apiBaseUrl;
+        this.apiBaseUrl = StringUtils.isEmpty(apiBaseUrl) ? DEFAULT_MABL_API_BASE_URL : apiBaseUrl;
     }
 
     @DataBoundSetter
     public void setAppBaseUrl(String appBaseUrl) {
-        this.appBaseUrl = appBaseUrl;
+        this.appBaseUrl = StringUtils.isEmpty(appBaseUrl) ? DEFAULT_MABL_APP_BASE_URL : appBaseUrl;
     }
 
     // Accessors to be used by Jelly UI templates

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
@@ -35,9 +35,9 @@
     </f:entry>
   </f:advanced>
   <f:invisibleEntry>
-    <f:textbox field="apiBaseUrl"/>
+    <f:textbox field="apiBaseUrl" default="https://api.mabl.com"/>
   </f:invisibleEntry>
   <f:invisibleEntry>
-    <f:textbox field="appBaseUrl"/>
+    <f:textbox field="appBaseUrl" default="https://app.mabl.com"/>
   </f:invisibleEntry>
 </j:jelly>


### PR DESCRIPTION
Unfortunately, I missed this problem. The endpoint URLs are not being currently populated unless the user sets in directly in the configuration XML file. This change sets the default in the template and also prevents from setting empty values on the endpoints.