### PR TITLE
Test and component updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Note that
 ### Change Log
 
 #### v0.0.32 (TBD)
--   Added retry logic to avoid early job completion in case failed plans are retried
+-   Added JaCoCo test coverage report and checks
 -   Updated JUnit, Mockito dependency
 -   Added unit test for branching
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ Note that
 
 ### Change Log
 
+#### v0.0.32 (TBD)
+-   Added retry logic to avoid early job completion in case failed plans are retried
+-   Updated JUnit, Mockito dependency
+-   Added unit test for branching
+
 #### v0.0.31 (08/12/2020)
 -   Fixed a regression related to default endpoints
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ Note that
 
 ### Change Log
 
-#### v0.0.32 (TBD)
+#### v0.0.32 (08/28/2020)
 -   Added JaCoCo test coverage report and checks
 -   Updated JUnit, Mockito dependency
 -   Added unit test for branching
+-   Revised Jenkins BOM dependency for compatibility reasons
 
 #### v0.0.31 (08/12/2020)
 -   Fixed a regression related to default endpoints

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.30</tag>
+        <tag>mabl-integration-0.0.32</tag>
     </scm>
 
     <repositories>
@@ -85,25 +85,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <groupId>org.junit</groupId>
+            <artifactId>junit-bom</artifactId>
+            <version>5.6.2</version>
+            <type>pom</type>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-library</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.4.6</version>
+            <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -131,7 +131,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
+                <artifactId>bom-2.164.x</artifactId>
                 <version>9</version>
                 <scope>import</scope>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,53 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>4.0.4</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- attached to Maven test phase -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>coverage-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>MISSEDCOUNT</value>
+                                            <maximum>7</maximum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
 
 </project>

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -144,21 +144,18 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
 
                 // Poll until we are successful or failed - note execution service is responsible for timeout
                 ExecutionResult executionResult = null;
-                for (int i=0; i<2; i++) {
-                    // Rerun this loop twice in case there are plan retries
-                    do {
-                        TimeUnit.MILLISECONDS.sleep(pollingIntervalMilliseconds);
-                        executionResult = client.getExecutionResults(deployment.id);
+                do {
+                    TimeUnit.MILLISECONDS.sleep(pollingIntervalMilliseconds);
+                    executionResult = client.getExecutionResults(deployment.id);
 
-                        if (executionResult == null) {
-                            // No such id - this shouldn't happen
-                            throw new MablSystemException("No deployment event found for id [%s] in mabl.", deployment.id);
-                        }
+                    if (executionResult == null) {
+                        // No such id - this shouldn't happen
+                        throw new MablSystemException("No deployment event found for id [%s] in mabl.", deployment.id);
+                    }
 
-                        printAllJourneyExecutionStatuses(executionResult);
+                    printAllJourneyExecutionStatuses(executionResult);
 
-                    } while (!allPlansComplete(executionResult));
-                }
+                } while (!allPlansComplete(executionResult));
 
                 printFinalStatuses(executionResult);
 

--- a/src/main/java/com/mabl/integration/jenkins/domain/ExecutionResult.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/ExecutionResult.java
@@ -164,6 +164,7 @@ public class ExecutionResult implements ApiResult {
     public static final class EventStatus {
         public Boolean succeeded;
         public Boolean succeededFirstAttempt;
+        public Boolean succeededWithRetries;
 
         public EventStatus(
         ) {
@@ -179,6 +180,11 @@ public class ExecutionResult implements ApiResult {
             return succeededFirstAttempt;
         }
 
+        @JsonGetter("succeeded_with_retries")
+        public Boolean getSucceededWithRetry() {
+            return succeededWithRetries;
+        }
+
         @JsonSetter("succeeded")
         public void setSucceeded(Boolean succeeded) {
             this.succeeded = succeeded;
@@ -187,6 +193,11 @@ public class ExecutionResult implements ApiResult {
         @JsonSetter("succeeded_first_attempt")
         public void setSucceededFirstAttempt(Boolean succeededFirstAttempt) {
             this.succeededFirstAttempt = succeededFirstAttempt;
+        }
+
+        @JsonSetter("succeeded_with_retries")
+        public void setSucceededWithRetry(Boolean succeededWithRetries) {
+            this.succeededWithRetries = succeededWithRetries;
         }
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/domain/ExecutionResult.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/ExecutionResult.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.google.common.collect.ImmutableCollection;
 
 import java.util.List;
 

--- a/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/Properties.java
@@ -35,10 +35,4 @@ public class Properties {
         properties.add(new Property(name, value));
     }
 
-    public void addProperties(Collection<Property> props) {
-        if (properties == null) {
-            properties = new ArrayList<>();
-        }
-        properties.addAll(props);
-    }
 }

--- a/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
+++ b/src/main/java/com/mabl/integration/jenkins/test/output/TestCase.java
@@ -54,13 +54,10 @@ public class TestCase {
     }
 
     public void setTestCaseIDs(final Collection<String> testCaseIDs) {
-        final List<Property> props = new ArrayList<>();
-        props.add(new Property("requirement", String.join(",", testCaseIDs)));
         if (properties == null) {
-            properties = new Properties(props);
-        } else {
-            properties.addProperties(props);
+            properties = new Properties();
         }
+        properties.addProperty("requirement", String.join(",", testCaseIDs));
     }
 
     public void setFailure(Failure failure) {

--- a/src/test/java/com/mabl/integration/jenkins/AbstractWiremockTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/AbstractWiremockTest.java
@@ -106,6 +106,40 @@ public abstract class AbstractWiremockTest {
         return mappedUrl;
     }
 
+    /**
+     * Register the local file to a mapping and provide full URL path
+     *
+     * @param path             mapped relative path
+     * @param responseBuilder  target response
+     * @param jsonResponseFile     return json body in this file on a hit
+     * @param expectedUsername required username
+     * @param expectedPassword required password
+     * @return mapped URL (full URL)
+     */
+    protected String registerGetMappingWithFile(
+            final String path,
+            final ResponseDefinitionBuilder responseBuilder,
+            final String jsonResponseFile,
+            final String expectedUsername,
+            final String expectedPassword
+    ) {
+
+        final String mappedUrl = generatePageUrl(path);
+        expectedUrls.put(path, "GET");
+
+        final MappingBuilder mappingBuilder = get(urlPathEqualTo(path))
+                .willReturn(responseBuilder
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile(jsonResponseFile));
+
+        mappingBuilder.withBasicAuth(expectedUsername, expectedPassword);
+        mappingBuilder.withHeader("user-agent", new EqualToPattern(PLUGIN_USER_AGENT));
+
+        stubFor(mappingBuilder);
+
+        return mappedUrl;
+    }
+
     protected void verifyExpectedUrls() {
         for (final Map.Entry<String, String> expectedUrlEntry : this.expectedUrls.entrySet()) {
 

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -28,6 +28,7 @@ import static com.mabl.integration.jenkins.MablRestApiClientImpl.DEPLOYMENT_RESU
 import static com.mabl.integration.jenkins.MablRestApiClientImpl.REST_API_USERNAME_PLACEHOLDER;
 import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -59,6 +60,66 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
         );
 
         assertSuccessfulCreateDeploymentRequest(fakeRestApiKeyId, environmentId, applicationId, labels);
+
+        // in reality, you would use the same event ID, but it is eeasier to test with separate ones
+        final String eventId1 = "fake-event-id-1";
+        final String eventId2 = "fake-event-id-2";
+        final String eventId3 = "fake-event-id-3";
+        registerGetMappingWithFile(
+                String.format(DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE, eventId1),
+                ok(),
+                "scheduled.json",
+                REST_API_USERNAME_PLACEHOLDER,
+                fakeRestApiKeyId
+        );
+        registerGetMappingWithFile(
+                String.format(DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE, eventId2),
+                ok(),
+                "retrying.json",
+                REST_API_USERNAME_PLACEHOLDER,
+                fakeRestApiKeyId
+        );
+        registerGetMappingWithFile(
+                String.format(DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE, eventId3),
+                ok(),
+                "retry-complete.json",
+                REST_API_USERNAME_PLACEHOLDER,
+                fakeRestApiKeyId
+        );
+
+
+        final String baseUrl = getBaseUrl();
+
+        MablRestApiClient client = null;
+        try {
+            client = new MablRestApiClientImpl(baseUrl, mockSecret(fakeRestApiKeyId), MABL_APP_BASE_URL);
+            ExecutionResult result = client.getExecutionResults(eventId1);
+            assertEquals("scheduled", result.executions.get(0).status);
+            assertNull(result.eventStatus.succeeded);
+            assertNull(result.eventStatus.succeededFirstAttempt);
+            assertNull(result.eventStatus.succeededWithRetries);
+
+            result = client.getExecutionResults(eventId2);
+            assertEquals("failed", result.executions.get(0).status);
+            assertEquals("scheduled", result.executions.get(1).status);
+            assertNull(result.eventStatus.succeeded);
+            assertNull(result.eventStatus.succeededFirstAttempt);
+            assertNull(result.eventStatus.succeededWithRetries);
+
+            result = client.getExecutionResults(eventId3);
+            assertEquals("failed", result.executions.get(0).status);
+            assertEquals("succeeded", result.executions.get(1).status);
+            assertTrue(result.eventStatus.succeeded);
+            assertFalse(result.eventStatus.succeededFirstAttempt);
+            assertTrue(result.eventStatus.succeededWithRetries);
+
+        } finally {
+            if (client != null) {
+                client.close();
+            }
+        }
+
+        verifyExpectedUrls();
     }
 
     @Test

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -118,6 +118,25 @@ public class MablRestApiClientTest extends AbstractWiremockTest {
         assertSuccessfulCreateDeploymentRequest(fakeRestApiKeyId, environmentId, applicationId, labels);
     }
 
+    @Test
+    public void createDeploymentRequestWithBranch() throws IOException {
+        final String fakeRestApiKeyId = "aFakeRestApiKeyId";
+        final String environmentId = "my-env-e";
+        final String applicationId = "my-app-a";
+        final String branch = "my-test-branch";
+
+        registerPostMapping(
+                MablRestApiClientImpl.DEPLOYMENT_TRIGGER_ENDPOINT,
+                MablTestConstants.CREATE_DEPLOYMENT_EVENT_RESULT_JSON,
+                REST_API_USERNAME_PLACEHOLDER,
+                fakeRestApiKeyId,
+                String.format("{\"environment_id\":\"%s\",\"application_id\":\"%s\",\"source_control_tag\":\"%s\",\"properties\":%s}",
+                        environmentId, applicationId, branch, fakeProperties)
+        );
+
+        assertSuccessfulCreateDeploymentRequest(fakeRestApiKeyId, environmentId, applicationId, null, branch);
+    }
+
     private void assertSuccessfulCreateDeploymentRequest(
             final String restApiKey,
             final String environmentId,

--- a/src/test/resources/__files/retry-complete.json
+++ b/src/test/resources/__files/retry-complete.json
@@ -1,0 +1,119 @@
+{
+  "event_status": {
+    "succeeded": true,
+    "succeeded_first_attempt": false,
+    "succeeded_with_retries": true,
+    "succeeded_by_plan": {
+      "GhoSTkwliRcUjJcxAWPFhw-p": true
+    }
+  },
+  "plan_execution_metrics": {
+    "total": 2,
+    "passed": 1,
+    "failed": 1
+  },
+  "journey_execution_metrics": {
+    "total": 2,
+    "passed": 1,
+    "failed": 1,
+    "running": 0,
+    "skipped": 0
+  },
+  "executions": [
+    {
+      "status": "failed",
+      "success": false,
+      "plan": {
+        "id": "GhoSTkwliRcUjJcxAWPFhw-p",
+        "name": "Succeeds on Rerun Plan",
+        "href": "https://api.mabl.com/schedule/runPolicy/GhoSTkwliRcUjJcxAWPFhw-p",
+        "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/plans/GhoSTkwliRcUjJcxAWPFhw-p"
+      },
+      "plan_execution": {
+        "id": "z5i7SKwiGEh7zWhPTC9ctQ-pr",
+        "status": "failed",
+        "href": "https://api.mabl.com/execution/runPolicyExecution/GhoSTkwliRcUjJcxAWPFhw-p",
+        "is_retry": false
+      },
+      "journeys": [
+        {
+          "id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "name": "Succeeds on Rerun Test",
+          "href": "https://api.mabl.com/test/journey/gPgREld17nYEn2qnlHZkjg-j:0",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/train/journeys/gPgREld17nYEn2qnlHZkjg-j/journeyrun/XuFMlmyfm34iwwMOPu4DWQ-jr"
+        }
+      ],
+      "journey_executions": [
+        {
+          "journey_id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "journey_execution_id": "XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "application_id": "DbFj4WJo5o3rkMgrkYqf0w-a",
+          "environment_id": "4_1-Mk0Dc3MLWhgYriTZCQ-e",
+          "initial_url": "https://sheety.co",
+          "run_multiplier_index": 0,
+          "browser_type": "chrome",
+          "status": "failed",
+          "status_cause": "Failed assertion that the variable with value 0 has a value equal to \"1\".",
+          "success": false,
+          "href": "https://api.mabl.com/execution/runPolicyExecution/z5i7SKwiGEh7zWhPTC9ctQ-pr/testScriptExecution/XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/journey-runs/XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "start_time": 1597771804290,
+          "stop_time": 1597771836333,
+          "failure_summary": {
+            "flow_id": "wDTRjEWi3iR1YBVM2e47yw-f:0",
+            "step_number": 5,
+            "error": "Failed assertion that the variable with value 0 has a value equal to \"1\".",
+            "image_href": "https://storage.googleapis.com/mabl-dev-workspace-aqw8f3ylzyjna4cp8keg4rhck8n/execution-output/bgzu/DbFj4WJo5o3rkMgrkYqf0w-a/GhoSTkwliRcUjJcxAWPFhw-p/z5i7SKwiGEh7zWhPTC9ctQ-pr/XuFMlmyfm34iwwMOPu4DWQ-jr/36/screenshot.png?GoogleAccessId=cloud-storage-signer@mabl-dev.iam.gserviceaccount.com&Expires=1598376643&Signature=PM3XWBlFy5zXFX4KQ3TtCY5jFoqp3Y9uudy3B%2FvrucgguVmVa6U1c7kVPsRTOmQlQ%2Fz7CN6aB%2BMmKwupl%2F16XKvcta3EcgbRCCZdnd7mUVF1qQr%2BDZ1%2Fx9rbfzqjKSaaIGV8p4%2FNoPXECzGsQ1VsJdEMni3K6rb2yCe15Be%2BqomSsGbuZvyto%2FHHHPsDzEp5Ya%2FR5LprQEq4IdEGtD3Ns0gdjv9jAd%2F9s4GW%2BwPmGDTAz7gRf2cq%2BUZv2cK0o%2BnyvfgpaT0YIzzfPMmhEHxq9weXbP6MGgLGTE4Gc90SiqTF78pLLiwFAbuBspzLQtn7vZQs6SO2P5rSzeB4uQNChg%3D%3D",
+            "image_artifact_url": "https://api.mabl.com/artifact?path=storage.googleapis.com%2Fmabl-dev-workspace-aqw8f3ylzyjna4cp8keg4rhck8n%2Fexecution-output%2Fbgzu%2FDbFj4WJo5o3rkMgrkYqf0w-a%2FGhoSTkwliRcUjJcxAWPFhw-p%2Fz5i7SKwiGEh7zWhPTC9ctQ-pr%2FXuFMlmyfm34iwwMOPu4DWQ-jr%2F36%2Fscreenshot.png"
+          }
+        }
+      ],
+      "start_time": 1597771802232,
+      "stop_time": 1597771844019
+    },
+    {
+      "status": "succeeded",
+      "success": true,
+      "plan": {
+        "id": "GhoSTkwliRcUjJcxAWPFhw-p",
+        "name": "Succeeds on Rerun Plan",
+        "href": "https://api.mabl.com/schedule/runPolicy/GhoSTkwliRcUjJcxAWPFhw-p",
+        "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/plans/GhoSTkwliRcUjJcxAWPFhw-p"
+      },
+      "plan_execution": {
+        "id": "T1Uk3JOQlwFwu5LAewHJMA-pr",
+        "status": "succeeded",
+        "href": "https://api.mabl.com/execution/runPolicyExecution/GhoSTkwliRcUjJcxAWPFhw-p",
+        "is_retry": true,
+        "retry_of_id": "z5i7SKwiGEh7zWhPTC9ctQ-pr"
+      },
+      "journeys": [
+        {
+          "id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "name": "Succeeds on Rerun Test",
+          "href": "https://api.mabl.com/test/journey/gPgREld17nYEn2qnlHZkjg-j:0",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/train/journeys/gPgREld17nYEn2qnlHZkjg-j/journeyrun/ABWViElPJE70uvsfJWatsQ-jr"
+        }
+      ],
+      "journey_executions": [
+        {
+          "journey_id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "journey_execution_id": "ABWViElPJE70uvsfJWatsQ-jr",
+          "application_id": "DbFj4WJo5o3rkMgrkYqf0w-a",
+          "environment_id": "4_1-Mk0Dc3MLWhgYriTZCQ-e",
+          "initial_url": "https://sheety.co",
+          "run_multiplier_index": 0,
+          "browser_type": "chrome",
+          "status": "completed",
+          "success": true,
+          "href": "https://api.mabl.com/execution/runPolicyExecution/T1Uk3JOQlwFwu5LAewHJMA-pr/testScriptExecution/ABWViElPJE70uvsfJWatsQ-jr",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/journey-runs/ABWViElPJE70uvsfJWatsQ-jr",
+          "start_time": 1597771856021,
+          "stop_time": 1597771896510
+        }
+      ],
+      "start_time": 1597771844074,
+      "stop_time": 1597771896671
+    }
+  ]
+}

--- a/src/test/resources/__files/retrying.json
+++ b/src/test/resources/__files/retrying.json
@@ -1,0 +1,108 @@
+{
+  "event_status": {},
+  "plan_execution_metrics": {
+    "total": 2,
+    "passed": 0,
+    "failed": 1
+  },
+  "journey_execution_metrics": {
+    "total": 2,
+    "passed": 0,
+    "failed": 1,
+    "running": 1,
+    "skipped": 0
+  },
+  "executions": [
+    {
+      "status": "failed",
+      "success": false,
+      "plan": {
+        "id": "GhoSTkwliRcUjJcxAWPFhw-p",
+        "name": "Succeeds on Rerun Plan",
+        "href": "https://api.mabl.com/schedule/runPolicy/GhoSTkwliRcUjJcxAWPFhw-p",
+        "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/plans/GhoSTkwliRcUjJcxAWPFhw-p"
+      },
+      "plan_execution": {
+        "id": "z5i7SKwiGEh7zWhPTC9ctQ-pr",
+        "status": "failed",
+        "href": "https://api.mabl.com/execution/runPolicyExecution/GhoSTkwliRcUjJcxAWPFhw-p",
+        "is_retry": false
+      },
+      "journeys": [
+        {
+          "id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "name": "Succeeds on Rerun Test",
+          "href": "https://api.mabl.com/test/journey/gPgREld17nYEn2qnlHZkjg-j:0",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/train/journeys/gPgREld17nYEn2qnlHZkjg-j/journeyrun/XuFMlmyfm34iwwMOPu4DWQ-jr"
+        }
+      ],
+      "journey_executions": [
+        {
+          "journey_id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "journey_execution_id": "XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "application_id": "DbFj4WJo5o3rkMgrkYqf0w-a",
+          "environment_id": "4_1-Mk0Dc3MLWhgYriTZCQ-e",
+          "initial_url": "https://sheety.co",
+          "run_multiplier_index": 0,
+          "browser_type": "chrome",
+          "status": "failed",
+          "status_cause": "Failed assertion that the variable with value 0 has a value equal to \"1\".",
+          "success": false,
+          "href": "https://api.mabl.com/execution/runPolicyExecution/z5i7SKwiGEh7zWhPTC9ctQ-pr/testScriptExecution/XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/journey-runs/XuFMlmyfm34iwwMOPu4DWQ-jr",
+          "start_time": 1597771804290,
+          "stop_time": 1597771836333,
+          "failure_summary": {
+            "flow_id": "wDTRjEWi3iR1YBVM2e47yw-f:0",
+            "step_number": 5,
+            "error": "Failed assertion that the variable with value 0 has a value equal to \"1\".",
+            "image_href": "https://storage.googleapis.com/mabl-dev-workspace-aqw8f3ylzyjna4cp8keg4rhck8n/execution-output/bgzu/DbFj4WJo5o3rkMgrkYqf0w-a/GhoSTkwliRcUjJcxAWPFhw-p/z5i7SKwiGEh7zWhPTC9ctQ-pr/XuFMlmyfm34iwwMOPu4DWQ-jr/36/screenshot.png?GoogleAccessId=cloud-storage-signer@mabl-dev.iam.gserviceaccount.com&Expires=1598376643&Signature=PM3XWBlFy5zXFX4KQ3TtCY5jFoqp3Y9uudy3B%2FvrucgguVmVa6U1c7kVPsRTOmQlQ%2Fz7CN6aB%2BMmKwupl%2F16XKvcta3EcgbRCCZdnd7mUVF1qQr%2BDZ1%2Fx9rbfzqjKSaaIGV8p4%2FNoPXECzGsQ1VsJdEMni3K6rb2yCe15Be%2BqomSsGbuZvyto%2FHHHPsDzEp5Ya%2FR5LprQEq4IdEGtD3Ns0gdjv9jAd%2F9s4GW%2BwPmGDTAz7gRf2cq%2BUZv2cK0o%2BnyvfgpaT0YIzzfPMmhEHxq9weXbP6MGgLGTE4Gc90SiqTF78pLLiwFAbuBspzLQtn7vZQs6SO2P5rSzeB4uQNChg%3D%3D",
+            "image_artifact_url": "https://api.mabl.com/artifact?path=storage.googleapis.com%2Fmabl-dev-workspace-aqw8f3ylzyjna4cp8keg4rhck8n%2Fexecution-output%2Fbgzu%2FDbFj4WJo5o3rkMgrkYqf0w-a%2FGhoSTkwliRcUjJcxAWPFhw-p%2Fz5i7SKwiGEh7zWhPTC9ctQ-pr%2FXuFMlmyfm34iwwMOPu4DWQ-jr%2F36%2Fscreenshot.png"
+          }
+        }
+      ],
+      "start_time": 1597771802232,
+      "stop_time": 1597771844019
+    },
+    {
+      "status": "scheduled",
+      "plan": {
+        "id": "GhoSTkwliRcUjJcxAWPFhw-p",
+        "name": "Succeeds on Rerun Plan",
+        "href": "https://api.mabl.com/schedule/runPolicy/GhoSTkwliRcUjJcxAWPFhw-p",
+        "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/plans/GhoSTkwliRcUjJcxAWPFhw-p"
+      },
+      "plan_execution": {
+        "id": "T1Uk3JOQlwFwu5LAewHJMA-pr",
+        "status": "scheduled",
+        "href": "https://api.mabl.com/execution/runPolicyExecution/GhoSTkwliRcUjJcxAWPFhw-p",
+        "is_retry": true,
+        "retry_of_id": "z5i7SKwiGEh7zWhPTC9ctQ-pr"
+      },
+      "journeys": [
+        {
+          "id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "name": "Succeeds on Rerun Test",
+          "href": "https://api.mabl.com/test/journey/gPgREld17nYEn2qnlHZkjg-j:0",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/train/journeys/gPgREld17nYEn2qnlHZkjg-j/journeyrun/ABWViElPJE70uvsfJWatsQ-jr"
+        }
+      ],
+      "journey_executions": [
+        {
+          "journey_id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "journey_execution_id": "ABWViElPJE70uvsfJWatsQ-jr",
+          "application_id": "DbFj4WJo5o3rkMgrkYqf0w-a",
+          "environment_id": "4_1-Mk0Dc3MLWhgYriTZCQ-e",
+          "initial_url": "https://sheety.co",
+          "run_multiplier_index": 0,
+          "browser_type": "chrome",
+          "status": "running",
+          "href": "https://api.mabl.com/execution/runPolicyExecution/T1Uk3JOQlwFwu5LAewHJMA-pr/testScriptExecution/ABWViElPJE70uvsfJWatsQ-jr",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/journey-runs/ABWViElPJE70uvsfJWatsQ-jr",
+          "start_time": 1597771856021
+        }
+      ],
+      "start_time": 1597771844074
+    }
+  ]
+}

--- a/src/test/resources/__files/scheduled.json
+++ b/src/test/resources/__files/scheduled.json
@@ -1,0 +1,56 @@
+{
+  "event_status": {},
+  "plan_execution_metrics": {
+    "total": 1,
+    "passed": 0,
+    "failed": 0
+  },
+  "journey_execution_metrics": {
+    "total": 1,
+    "passed": 0,
+    "failed": 0,
+    "running": 1,
+    "skipped": 0
+  },
+  "executions": [
+    {
+      "status": "scheduled",
+      "plan": {
+        "id": "GhoSTkwliRcUjJcxAWPFhw-p",
+        "name": "Succeeds on Rerun Plan",
+        "href": "https://api.mabl.com/schedule/runPolicy/GhoSTkwliRcUjJcxAWPFhw-p",
+        "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/plans/GhoSTkwliRcUjJcxAWPFhw-p"
+      },
+      "plan_execution": {
+        "id": "JCOdn4hwOz6ZvFaf020S6Q-pr",
+        "status": "scheduled",
+        "href": "https://api.mabl.com/execution/runPolicyExecution/GhoSTkwliRcUjJcxAWPFhw-p",
+        "is_retry": false
+      },
+      "journeys": [
+        {
+          "id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "name": "Succeeds on Rerun Test",
+          "href": "https://api.mabl.com/test/journey/gPgREld17nYEn2qnlHZkjg-j:0",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/train/journeys/gPgREld17nYEn2qnlHZkjg-j/journeyrun/vtVOeF37R0OhPxwBY6f5MQ-jr"
+        }
+      ],
+      "journey_executions": [
+        {
+          "journey_id": "gPgREld17nYEn2qnlHZkjg-j:0",
+          "journey_execution_id": "vtVOeF37R0OhPxwBY6f5MQ-jr",
+          "application_id": "DbFj4WJo5o3rkMgrkYqf0w-a",
+          "environment_id": "4_1-Mk0Dc3MLWhgYriTZCQ-e",
+          "initial_url": "https://sheety.co",
+          "run_multiplier_index": 0,
+          "browser_type": "chrome",
+          "status": "running",
+          "href": "https://api.mabl.com/execution/runPolicyExecution/JCOdn4hwOz6ZvFaf020S6Q-pr/testScriptExecution/vtVOeF37R0OhPxwBY6f5MQ-jr",
+          "app_href": "https://app.mabl.com/workspaces/lwCaU5I1pmmRfzIepmUKLg-w/test/journey-runs/vtVOeF37R0OhPxwBY6f5MQ-jr",
+          "start_time": 1597772403758
+        }
+      ],
+      "start_time": 1597772401586
+    }
+  ]
+}


### PR DESCRIPTION
Since the plan retry is no longer necessary, I updated this PR to include
* updates to components (JUnit4 -> Junit5, update to wiremock)
* the succeeded_with_retries in the EventStatus object
* new tests for checking different execution states
* JaCoCo code coverage report as well as checks (if this works, the next would be to create a badge on the project page to show the code coverage metrics)