### PR TITLE
Make plugin compatible with Jenkins Enterprise 2.190.3.2 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Note that
 
 ### Change Log
 
+#### v0.0.33 (09/04/2020)
+-   Set explicit dependency on credentials and plain credentials
+    dependency to address incompatibility issue with Jenkins Enterprise
+
 #### v0.0.32 (08/28/2020)
 -   Added JaCoCo test coverage report and checks
 -   Updated JUnit, Mockito dependency

--- a/pom.xml
+++ b/pom.xml
@@ -120,10 +120,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I received new information that makes our plugin compatible with Jenkins Enterprise 2.190.3.2. Unfortunately, for me to test this, I need to release a new version. Without explicitly setting the version of the credentials and plain credentials plugins, newer versions are picked up making it incompatible with this version of Jenkins Enterprise.