### PR TITLE
Minor changes to address label parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ Note that
 
 ### Change Log
 
+#### v0.0.36 (10/05/2020)
+-   Updated Wiremock, JUnit, Jackson, Spotbugs and JaCoCo dependencies
+-   Added validation for branch field
+-   Added trimming whitespaces from labels
+
 #### v0.0.35 (09/29/2020)
 -   Remove use of deprecated API endpoint
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,20 +81,20 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.27.1</version>
+            <version>2.27.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
-            <version>5.6.2</version>
+            <version>5.7.0</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.2</version>
+            <version>3.5.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -105,17 +105,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -154,12 +154,12 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.4</version>
+                <version>4.1.3</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -33,7 +33,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import javax.annotation.Nonnull;
-import javax.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -91,7 +90,11 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setLabels(String labels) {
-        this.labels = labels;
+        String value = labels;
+        if (!StringUtils.isEmpty(labels)) {
+            value = labels.trim().replaceAll(",[\\s]+", ",");
+        }
+        this.labels = value;
     }
 
     @DataBoundSetter
@@ -334,7 +337,7 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
                 @AncestorInPath Item item,
                 @QueryParameter String value
         ) {
-            if (item == null || StringUtils.isBlank(value)) {
+            if (StringUtils.isBlank(value)) {
                     return FormValidation.warning("Provide a credentials ID");
             } else if (!item.hasPermission(Item.EXTENDED_READ) && !item.hasPermission(USE_ITEM)) {
                 return FormValidation.warning("Insufficient permissions");
@@ -429,6 +432,21 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
             }
 
             return getSelectValidApiKeyListBoxModel();
+        }
+
+        public FormValidation doCheckMablBranch(
+                @QueryParameter String value
+        ) {
+            if (StringUtils.isEmpty(value)) {
+                return FormValidation.ok();
+            }
+
+            if (value.matches("[A-Za-z0-9_-]+")) {
+                return FormValidation.ok();
+            }
+
+            return FormValidation.error("The branch name field may only contain alpha-numeric characters, " +
+                    "as well as dashes and underscores.");
         }
 
         private static ListBoxModel getSelectValidApiKeyListBoxModel() {

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDescriptorTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDescriptorTest.java
@@ -1,0 +1,143 @@
+package com.mabl.integration.jenkins;
+
+import hudson.model.AbstractItem;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.security.Permission;
+import hudson.util.FormValidation;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static com.cloudbees.plugins.credentials.CredentialsProvider.USE_ITEM;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+
+public class MablStepDescriptorTest {
+
+    private MablStepBuilder.MablStepDescriptor descriptor;
+
+    @Before
+    public void setup() {
+        descriptor = mock(MablStepBuilder.MablStepDescriptor.class);
+        doNothing().when(descriptor).load();
+    }
+
+    @Test
+    public void testCheckRestApiKeyIds_Blank() {
+        Item item = new AbstractItem(null, "testItem") {
+            @Override
+            public Collection<? extends Job> getAllJobs() {
+                return null;
+            }
+
+            @Override
+            public boolean hasPermission(Permission permission) {
+                return EXTENDED_READ.equals(permission);
+            }
+        };
+        when(descriptor.doCheckRestApiKeyIds(item, null)).thenCallRealMethod();
+        assertNotEquals(FormValidation.ok(), descriptor.doCheckRestApiKeyIds(item, null));
+        when(descriptor.doCheckRestApiKeyIds(item, "")).thenCallRealMethod();
+        assertNotEquals(FormValidation.ok(), descriptor.doCheckRestApiKeyIds(item, ""));
+    }
+
+    @Test
+    public void testCheckRestApiKeyIds_ExtendedRead() {
+        Item item = new AbstractItem(null, "testItem") {
+            @Override
+            public Collection<? extends Job> getAllJobs() {
+                return null;
+            }
+
+            @Override
+            public boolean hasPermission(Permission permission) {
+                return EXTENDED_READ.equals(permission);
+            }
+        };
+        when(descriptor.doCheckRestApiKeyIds(item, "an-api-key")).thenCallRealMethod();
+        assertEquals(FormValidation.ok(), descriptor.doCheckRestApiKeyIds(item, "an-api-key"));
+    }
+
+    @Test
+    public void testCheckRestApiKeyIds_UseItem() {
+        Item item = new AbstractItem(null, "testItem") {
+            @Override
+            public Collection<? extends Job> getAllJobs() {
+                return null;
+            }
+
+            @Override
+            public boolean hasPermission(Permission permission) {
+                return USE_ITEM.equals(permission);
+            }
+        };
+        when(descriptor.doCheckRestApiKeyIds(item, "an-api-key")).thenCallRealMethod();
+        assertEquals(FormValidation.ok(), descriptor.doCheckRestApiKeyIds(item, "an-api-key"));
+    }
+
+    @Test
+    public void testCheckRestApiKeyIds_InsufficentPermissions() {
+        Item item = new AbstractItem(null, "testItem") {
+            @Override
+            public Collection<? extends Job> getAllJobs() {
+                return null;
+            }
+
+            @Override
+            public boolean hasPermission(Permission permission) {
+                return false;
+            }
+        };
+        when(descriptor.doCheckRestApiKeyIds(item, "an-api-key")).thenCallRealMethod();
+        assertNotEquals(FormValidation.ok(),
+                descriptor.doCheckRestApiKeyIds(item, "an-api-key"));
+    }
+
+    @Test
+    public void testCheckRestApiKeyIds_ExpressionBasedCreds() {
+        Item item = new AbstractItem(null, "testItem") {
+            @Override
+            public Collection<? extends Job> getAllJobs() {
+                return null;
+            }
+
+            @Override
+            public boolean hasPermission(Permission permission) {
+                return true;
+            }
+        };
+        when(descriptor.doCheckRestApiKeyIds(item, "${invalidName}")).thenCallRealMethod();
+        assertNotEquals(FormValidation.ok(),
+                descriptor.doCheckRestApiKeyIds(item, "${invalidName}"));
+
+        when(descriptor.doCheckRestApiKeyIds(item, "${couldBeValid")).thenCallRealMethod();
+        assertEquals(FormValidation.ok(),
+                descriptor.doCheckRestApiKeyIds(item, "${couldBeValid"));
+    }
+
+    @Test
+    public void testCheckMablBranch_Valid()
+    {
+        when(descriptor.doCheckMablBranch(null)).thenCallRealMethod();
+        assertEquals(FormValidation.ok(), descriptor.doCheckMablBranch(null));
+
+        when(descriptor.doCheckMablBranch("")).thenCallRealMethod();
+        assertEquals(FormValidation.ok(), descriptor.doCheckMablBranch(""));
+
+        when(descriptor.doCheckMablBranch("A_Valid_Branch-Name")).thenCallRealMethod();
+        assertEquals(FormValidation.ok(), descriptor.doCheckMablBranch("A_Valid_Branch-Name"));
+    }
+
+    @Test
+    public void testCheckMablBranch_InValid()
+    {
+        when(descriptor.doCheckMablBranch("Br@nch1nv@l1d")).thenCallRealMethod();
+        assertNotEquals(FormValidation.ok(), descriptor.doCheckMablBranch("Br@nch1nv@l1d"));
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Updated the code to trim whitespace around the commas when multiple labels are provided and this can cause a problem as labels may include spaces (except for a leading/trailing one). The code has been updated so that it will tolerate spaces, but will save and use the values without these extra spaces.

Added validation on the mabl Branch name to avoid saving branch names with invalid characters.

Added a test for the new validation methods.

Updated components

