### PR TITLE
Update timeouts when interacting with the mabl API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Note that
 
 ### Change Log
 
+#### v0.0.39 (05/25/2021)
+- Increased request timeout for interacting with mabl API
+- Added retry handler for idempotent operations when interacting with mabl API
+- Update components: Wiremock, JUnit5, GSON, Spotbugs, JaCoCo
+
 #### v0.0.38 (04/01/2021)
 -   Added support for running plugin with Java Runtime Environment 11
 -   Added GSON library for deserializing from JSON

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,13 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.27.2</version>
+            <version>2.28.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
-            <version>5.7.1</version>
+            <version>5.7.2</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -139,12 +139,12 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.0</version>
+                <version>4.2.3</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
@@ -52,7 +53,6 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -119,7 +119,8 @@ public class MablRestApiClientImpl implements MablRestApiClient {
                 // TODO why isn't this setting the required Basic auth headers? Hardcoded as work around.
                 .setDefaultCredentialsProvider(getApiCredentialsProvider(restApiKey))
                 .setUserAgent(PLUGIN_USER_AGENT) // track calls @ API level
-                .setConnectionTimeToLive(30, TimeUnit.SECONDS) // use keep alive in SSL API connections
+                .setConnectionTimeToLive(60, TimeUnit.SECONDS) // use keep alive in SSL API connections
+                .setRetryHandler(new StandardHttpRequestRetryHandler(3, true))
                 .setDefaultRequestConfig(getDefaultRequestConfig());
 
         if (disableSslVerification) {

--- a/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepConstants.java
@@ -33,7 +33,7 @@ public class MablStepConstants {
     public static final String DEFAULT_MABL_API_BASE_URL = "https://api.mabl.com";
     public static final String DEFAULT_MABL_APP_BASE_URL = "https://app.mabl.com";
     static final int EXECUTION_TIMEOUT_SECONDS = 3600;
-    static final int REQUEST_TIMEOUT_MILLISECONDS = 60000;
+    static final int REQUEST_TIMEOUT_MILLISECONDS = 120000;
     static final long EXECUTION_STATUS_POLLING_INTERNAL_MILLISECONDS = 10000;
 
     // Form labels


### PR DESCRIPTION
* Update request timeout for interacting with mabl API
* Add retry handler for idempotent operations when interacting with mabl API
* Update components: wiremock, junit5, GSON, Spotbugs, JaCoCo

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
