### PR TITLE
MABL-5019: Update credentials plugin dependency to address security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Note that
 
 ### Change Log
 
-#### v0.0.49 (07/07/2021)
+#### v0.0.40 (07/07/2021)
 - Changed minimum Jenkins version to 2.222.4 (pre-requisite for updating credentials plugin dependency)
 - Updated credentials plugin dependency to address security vulnerability
 - Updated plain-credentials, wiremock dependencies

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install the [plugin](https://plugins.jenkins.io/mabl-integration) into your Jenk
 
 ### Requirements
 
--   Minimum Jenkins version: *2.164.3*
+-   Minimum Jenkins version: *2.222.4*
 -   Minimum Java runtime version: *8*
 -   mabl API key
     -   See [integration
@@ -176,6 +176,11 @@ Note that
   1. Update the mabl step in each affected job 
 
 ### Change Log
+
+#### v0.0.49 (07/07/2021)
+- Changed minimum Jenkins version to 2.222.4 (pre-requisite for updating credentials plugin dependency)
+- Updated credentials plugin dependency to address security vulnerability
+- Updated plain-credentials, wiremock dependencies
 
 #### v0.0.39 (05/25/2021)
 - Increased request timeout for interacting with mabl API

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <!-- NOTE: this version drives the minimum Jenkins version that the plugin can be installed on -->
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
 
@@ -70,10 +70,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
@@ -81,7 +77,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.28.0</version>
+            <version>2.29.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -106,13 +102,13 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <!-- see the Jenkins Enterprise compatibility note in the README before changing this version -->
-            <version>2.3.0</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
             <!-- see the Jenkins Enterprise compatibility note in the README before changing this version -->
-            <version>1.5</version>
+            <version>1.7</version>
         </dependency>
     </dependencies>
 
@@ -120,8 +116,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.164.x</artifactId>
-                <version>9</version>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>26</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
* Changed minimum Jenkins version to 2.222.4 (pre-requisite for updating credentials plugin dependency)
* Update plain-credentials and wiremock dependencies


- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
