### PR TITLE
MABL-5770: fix the recorded test case IDs in the JUnit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Note that
 
 ### Change Log
 
+#### v0.0.41 (10/06/2021)
+- Fixed an issue where the associated test cases IDs were incorrectly recorded in the generated JUnit report
+- Updated WireMock, JUnit, GSON, SpotBugs dependencies
+
 #### v0.0.40 (07/07/2021)
 - Changed minimum Jenkins version to 2.222.4 (pre-requisite for updating credentials plugin dependency)
 - Updated credentials plugin dependency to address security vulnerability

--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,13 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.29.0</version>
+            <version>2.31.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
-            <version>5.7.2</version>
+            <version>5.8.1</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.7</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.3</version>
+                <version>4.4.1</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -315,9 +315,11 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
                     case "failed":
                     case "completed":
                     case "skipped":
-                        final SortedSet<String> ids =
+                        final SortedSet<String> allIds =
                                 testCaseIDs.computeIfAbsent(journeyResult.status + "-test-cases", k -> new TreeSet<>());
+                        final SortedSet<String> ids = new TreeSet<>();
                         for (ExecutionResult.TestCaseID id : journeyResult.testCases) {
+                            allIds.add(id.caseID);
                             ids.add(id.caseID);
                         }
 

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -360,7 +360,7 @@ public class MablStepDeploymentRunnerTest {
         }
     }
 
-    @Test
+    @Test(timeout = 600000)
     public void executionSummary_testCaseIdsAndSkipped() {
         ExecutionResult executionResult = createExecutionResultWithTestCaseIds();
         for (ExecutionResult.ExecutionSummary summary : executionResult.executions) {
@@ -375,7 +375,7 @@ public class MablStepDeploymentRunnerTest {
             for (Property property : propertyCollection) {
                 switch (property.getName()) {
                     case "failed-test-cases":
-                        assertEquals("FAILED-1,FAILED-91", property.getValue());
+                        assertEquals("FAILED-1,FAILED-11,FAILED-91", property.getValue());
                         foundFailed = true;
                         break;
                     case "completed-test-cases":
@@ -393,9 +393,9 @@ public class MablStepDeploymentRunnerTest {
             assertTrue(foundCompleted);
             assertTrue(foundFailed);
             assertTrue(foundSkipped);
-            assertEquals(1, suite.getFailures());
+            assertEquals(2, suite.getFailures());
             assertEquals(1, suite.getSkipped());
-            assertEquals(3, suite.getTests());
+            assertEquals(4, suite.getTests());
 
             for (TestCase testCase : suite.getTestCases()) {
                 Properties caseProperties = testCase.getProperties();
@@ -405,7 +405,11 @@ public class MablStepDeploymentRunnerTest {
                 Property caseProperty = casePropertyCollection.iterator().next();
                 assertEquals("requirement", caseProperty.getName());
                 if (testCase.getFailure() != null) {
-                    assertEquals("FAILED-1,FAILED-91", caseProperty.getValue());
+                    if ("failingTestRun-jr".equals(testCase.getJourney())) {
+                        assertEquals("FAILED-1,FAILED-91", caseProperty.getValue());
+                    } else if ("failingTestRun2-jr".equals(testCase.getJourney())) {
+                        assertEquals("FAILED-11", caseProperty.getValue());
+                    }
                     assertNull(testCase.getSkipped());
                 } else if (testCase.getSkipped() != null) {
                     assertEquals("SKIPPED-3,SKIPPED-33,SKIPPED-333", caseProperty.getValue());
@@ -471,7 +475,19 @@ public class MablStepDeploymentRunnerTest {
                                                         1596323475002L,
                                                         1596323565002L,
                                                         singletonList(
-                                                                new ExecutionResult.TestCaseID("COMPLETED-2")))
+                                                                new ExecutionResult.TestCaseID("COMPLETED-2"))),
+                                                new ExecutionResult.JourneyExecutionResult(
+                                                        "failingTestRun2-jr",
+                                                        "executionId4",
+                                                        "http://www.example.com",
+                                                        "http://app.example.com",
+                                                        "failed",
+                                                        "failed because ",
+                                                        false,
+                                                        1596323475003L,
+                                                        1596323565003L,
+                                                        Arrays.asList(
+                                                                new ExecutionResult.TestCaseID("FAILED-11")))
                                         )
                                 )
                 ),

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -360,7 +360,7 @@ public class MablStepDeploymentRunnerTest {
         }
     }
 
-    @Test(timeout = 600000)
+    @Test
     public void executionSummary_testCaseIdsAndSkipped() {
         ExecutionResult executionResult = createExecutionResultWithTestCaseIds();
         for (ExecutionResult.ExecutionSummary summary : executionResult.executions) {


### PR DESCRIPTION
As reported in [MABL-5770](https://mabl.atlassian.net/browse/MABL-5770), the test case IDs reported for individual test cases were incorrectly recorded. Test case IDs are reported both at the individual test level as well as in the summary section. The code used to set the per test IDs to the global list as it was generating the report. The code and tests have been updated to keep the global list and the per test list separate.

Also: updated SpotBugs, JUnit, WireMock, GSON dependencies.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
