### PR TITLE
Added null and empty testing to restApiKey

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -153,8 +153,15 @@ public class MablRestApiClientImpl implements MablRestApiClient {
             final Secret restApiKey
     ) {
         final CredentialsProvider provider = new BasicCredentialsProvider();
+
+        // Adding check for null or empty restApiKey
+        final String keyTest = restApiKey.getPlainText();
+        if (keyTest == null || keyTest.trim().isEmpty()) {
+            throw new IllegalArgumentException ("API key not found");
+        }
+
         final UsernamePasswordCredentials creds =
-                new UsernamePasswordCredentials(REST_API_USERNAME_PLACEHOLDER, restApiKey.getPlainText());
+                new UsernamePasswordCredentials(REST_API_USERNAME_PLACEHOLDER, keyTest);
 
         provider.setCredentials(AuthScope.ANY, creds);
 


### PR DESCRIPTION
Was getting a NullPointerException when the APIKey was invalid or null, threw a slightly more useful error.
