### PR TITLE
Replace deprecated usages with non-deprecated equivalents

### DIFF
--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientImpl.java
@@ -61,9 +61,9 @@ import javax.net.ssl.SSLContext;
 
 import static com.mabl.integration.jenkins.MablStepConstants.PLUGIN_USER_AGENT;
 import static com.mabl.integration.jenkins.MablStepConstants.REQUEST_TIMEOUT_MILLISECONDS;
-import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
-import static org.apache.commons.httpclient.HttpStatus.SC_NOT_FOUND;
-import static org.apache.commons.httpclient.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_OK;
 
 /**
  * mabl runner to launch all plans for a given

--- a/src/main/java/com/mabl/integration/jenkins/MablRestApiClientRetryHandler.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablRestApiClientRetryHandler.java
@@ -6,8 +6,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.protocol.HttpContext;
 
-import static org.apache.commons.httpclient.HttpStatus.SC_NOT_IMPLEMENTED; // 501
-import static org.apache.commons.httpclient.HttpStatus.SC_BAD_GATEWAY; // 502
+import static org.apache.http.HttpStatus.SC_NOT_IMPLEMENTED; // 501
+import static org.apache.http.HttpStatus.SC_BAD_GATEWAY; // 502
 
 public class MablRestApiClientRetryHandler implements ServiceUnavailableRetryStrategy {
 

--- a/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablRestApiClientTest.java
@@ -28,7 +28,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.mabl.integration.jenkins.MablRestApiClientImpl.DEPLOYMENT_RESULT_ENDPOINT_TEMPLATE;
 import static com.mabl.integration.jenkins.MablRestApiClientImpl.REST_API_USERNAME_PLACEHOLDER;
-import static org.apache.commons.httpclient.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
This plugin uses a mix of imports from Commons HttpClient 3.x (which is deprecated) and 4.x (which is not deprecated). This PR replaces all the deprecated 3.x imports with non-deprecated 4.x equivalents.