### PR TITLE
Manually release 0.0.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.47-SNAPSHOT</version>
+    <version>0.0.47</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.32</tag>
+        <tag>mabl-integration-0.0.47</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.47</version>
+    <version>0.0.48-SNAPSHOT</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.47</tag>
+        <tag>mabl-integration-0.0.32</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
## Description
Due to new branch protection rules our release script isn't functioning as intended. Going to deploy from this branch, then manually prepare for next developer iteration.
