### PR TITLE
Fix: documentation link

### DIFF
--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-restApiKeyId.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-restApiKeyId.html
@@ -3,5 +3,5 @@
     text kind. Make sure that you set the ID of the credential as IDs are used to select the credential from the
     drop-down list.  The scope of the credential must be Global and the credential may be kept in any domain (including
     the unrestricted Global credentials or any other domain).
-    <a target="_blank" href="https://help.mabl.com/v1.0/docs/triggering-tests-via-the-api">More info</a>.
+    <a target="_blank" href="https://help.mabl.com/hc/articles/17780788992148">More info</a>.
 </div>


### PR DESCRIPTION
Fixes a 404 on a documentation link and updates it with the correct URL.

![imagen](https://github.com/jenkinsci/mabl-integration-plugin/assets/5454742/d327f06b-b3d6-4fbd-b657-c3942d28da21)
