### PR TITLE
[maven-release-plugin] prepare release mabl-integration-0.0.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.48-SNAPSHOT</version>
+    <version>0.0.48</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.32</tag>
+        <tag>mabl-integration-0.0.48</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
## Description

Due to branch protection rules our release script isn't functioning as intended, updating through PR instead.

![imagen](https://github.com/jenkinsci/mabl-integration-plugin/assets/5454742/7d21d6d3-6332-45bb-9902-d13a1980763f)
