### PR TITLE
[MABL-14086] Bump Java, Jenkins and update documentation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin allows easy launching of [mabl](https://www.mabl.com) tests as a ste
   * [Deployment](#deployment)
 
 ## Plugin Installation
-Install the [plugin](https://plugins.jenkins.io/mabl-integration) into your Jenkins `v2.319.1+` server from the *Available Plugins* tab by searching for "mabl".
+Install the [plugin](https://plugins.jenkins.io/mabl-integration) into your Jenkins `v2.387.3+` server from the *Available Plugins* tab by searching for "mabl".
 
 ### Features
 
@@ -30,8 +30,8 @@ Install the [plugin](https://plugins.jenkins.io/mabl-integration) into your Jenk
 
 ### Requirements
 
--   Minimum Jenkins version: *2.319.1*
--   Minimum Java runtime version: *8*
+-   Minimum Jenkins version: *2.387.3*
+-   Minimum Java runtime version: *11*
 -   mabl API key
     -   See [integration
         docs](https://help.mabl.com/v1.0/docs/integrating-mabl-with-your-cicd-workflow#section-the-mabl-deployment-events-api)
@@ -185,6 +185,10 @@ Note that
   1. Update the mabl step in each affected job 
 
 ### Change Log
+
+#### v0.0.49 (08/20/2024)
+- Update documentation
+- Increased minimum Jenkins version
 
 #### v0.0.48 (03/13/2024)
 - Fix broken documentation link

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ configured, make sure that you update the value to be a comma-separated list of 
 
 Note that
 * Jenkins versions 1.x are no longer supported
-* Minimum required Java version is Java 8
+* Minimum required Java version is Java 11
 * Jobs with mabl steps will have to be _manually_ updated
   1. Create a Secret text kind credential to store the mabl API key. The scope of the credential must be set to Global.
      The credential may be placed in any of the credential domains.

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <jenkins.version>2.387.3</jenkins.version>
 		<java.level>11</java.level>
 		<java.version>${java.level}</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
@@ -142,9 +144,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
-				<configuration>
-					<release>${java.level}</release>
-				</configuration>
 			</plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.52</version>
         <relativePath />
     </parent>
 
@@ -117,8 +117,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>26</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>1834.vc26f653a_a_b_10</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <properties>
         <!-- NOTE: this version drives the minimum Jenkins version that the plugin can be installed on -->
         <jenkins.version>2.387.3</jenkins.version>
-		<java.level>11</java.level>
-		<java.version>11</java.version>
+        <java.level>11</java.level>
+        <java.version>${java.level}</java.version>
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
@@ -143,23 +143,23 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-					<release>${java.level}</release>
-				</configuration>
-			</plugin>
+                    <release>${java.level}</release>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
-					<minimumJavaVersion>${java.level}</minimumJavaVersion>
-				</configuration>
+                    <minimumJavaVersion>${java.level}</minimumJavaVersion>
+                </configuration>
             </plugin>
             <plugin>
-				<groupId>org.kohsuke</groupId>
-			    <artifactId>access-modifier-checker</artifactId>
-			    <configuration>
-			        <skip>true</skip>
-			    </configuration>
-			</plugin>
+                <groupId>org.kohsuke</groupId>
+                <artifactId>access-modifier-checker</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
     <properties>
         <!-- NOTE: this version drives the minimum Jenkins version that the plugin can be installed on -->
         <jenkins.version>2.387.3</jenkins.version>
-        <java.level>11</java.level>
+		<java.level>11</java.level>
+		<java.version>${java.level}</java.version>
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
@@ -138,10 +139,25 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.level}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.19</version>
+                <configuration>
+					<minimumJavaVersion>${java.level}</minimumJavaVersion>
+				</configuration>
             </plugin>
+            <plugin>
+				<groupId>org.kohsuke</groupId>
+			    <artifactId>access-modifier-checker</artifactId>
+			    <configuration>
+			        <skip>true</skip>
+			    </configuration>
+			</plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,10 @@
             <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.8.0</version>
+				<configuration>
+					<release>${java.level}</release>
+				</configuration>
 			</plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.2</version>
+        <version>4.52</version>
         <relativePath />
     </parent>
 
@@ -23,12 +23,11 @@
         <!-- NOTE: this version drives the minimum Jenkins version that the plugin can be installed on -->
         <jenkins.version>2.387.3</jenkins.version>
 		<java.level>11</java.level>
-		<java.version>${java.level}</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+		<java.version>11</java.version>
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
+        <!-- <jenkins-test-harness.version>2.34</jenkins-test-harness.version> -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <concurrency>1</concurrency>
         <hpi.compatibleSinceVersion>0.0.30</hpi.compatibleSinceVersion>
@@ -96,6 +95,11 @@
             <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- <dependency>
+			<groupId>org.jenkins-ci.main</groupId>
+			<artifactId>jenkins-test-harness</artifactId>
+			<version>1802.v9de0d87365d2</version>
+		</dependency> -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -141,9 +145,12 @@
     <build>
         <plugins>
             <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+					<release>${java.level}</release>
+				</configuration>
 			</plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.48</version>
+    <version>0.0.49</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -21,8 +21,8 @@
 
     <properties>
         <!-- NOTE: this version drives the minimum Jenkins version that the plugin can be installed on -->
-        <jenkins.version>2.319.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.387.3</jenkins.version>
+        <java.level>11</java.level>
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
@@ -51,7 +51,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.48</tag>
+        <tag>mabl-integration-0.0.49</tag>
     </scm>
 
     <repositories>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.31.0</version>
+            <version>2.35.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -129,7 +129,7 @@
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
-                <version>1.23</version>
+                <version>1.24</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.52</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
 
@@ -27,7 +27,6 @@
         <no-test-jar>false</no-test-jar>
 
         <release.skipTests>false</release.skipTests>
-        <!-- <jenkins-test-harness.version>2.34</jenkins-test-harness.version> -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <concurrency>1</concurrency>
         <hpi.compatibleSinceVersion>0.0.30</hpi.compatibleSinceVersion>
@@ -95,11 +94,6 @@
             <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- <dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>jenkins-test-harness</artifactId>
-			<version>1802.v9de0d87365d2</version>
-		</dependency> -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -147,7 +141,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
 					<release>${java.level}</release>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
-				<configuration>
-					<release>${java.level}</release>
-				</configuration>
 			</plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,11 +139,13 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>${java.level}</release>
-                </configuration>
-            </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<release>${java.level}</release>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>


### PR DESCRIPTION
Based on the Jenkins documentation: https://www.jenkins.io/blog/2022/12/14/require-java-11/

## New requirements:
* At least Jenkins version `2.387.3`
* At least Java 11

### Submitter checklist
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
