### PR TITLE
Fix 0.0.49 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,9 +457,10 @@ Now you can test your plugin.
 
 Before making a new plugin release, ensure code is in high quality, fully tested state. See [extra checks](https://wiki.jenkins.io/display/JENKINS/Plugin+Release+Tips).
 
-1. Update your `~/.m2/settings.xml` according to the [Jenkins docs](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Releasingtojenkins-ci.org).
-2. Setup and run a GitHub [ssh agent](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#adding-your-ssh-key-to-the-ssh-agent).
-3. Run `mvn release:prepare release:perform -B` from the HEAD of main
-4. Run `mvn deploy` on success of above step.
+1. Make sure you bump `pom.xml` version with `-SNAPSHOT` in your PR before merging to main
+2. Update your `~/.m2/settings.xml` according to the [Jenkins docs](https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Releasingtojenkins-ci.org).
+3. Setup and run a GitHub [ssh agent](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#adding-your-ssh-key-to-the-ssh-agent).
+4. Run `mvn release:prepare release:perform -B` from the HEAD of main
+5. Run `mvn deploy` on success of above step.
 
 Wait ~8 hours for plugin to become GA across all Jenkins instances under the "Available Plugins" listing.

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.49-SNAPSHOT</tag>
+        <tag>mabl-integration-0.0.49</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.48</version>
+    <version>0.0.49-SNAPSHOT</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.48</tag>
+        <tag>mabl-integration-0.0.49-SNAPSHOT</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.mabl.integration.jenkins</groupId>
     <artifactId>mabl-integration</artifactId>
     <packaging>hpi</packaging>
-    <version>0.0.49</version>
+    <version>0.0.48</version>
 
     <name>mabl</name>
     <description>Launch mabl journeys from CI builds</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/mabl-integration-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/mabl-integration-plugin</url>
-        <tag>mabl-integration-0.0.49</tag>
+        <tag>mabl-integration-0.0.48</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
Run into an issue deploying and my guess is it might be related to the manual bump on the version.

I'm running into a `status: 403 Forbidden` and the documentation is not very helpful: https://wiki.jenkins.io/display/JENKINS/Hosting+Plugins#HostingPlugins-Releasingtojenkins-ci.org
