### PR TITLE
Add URL override fields for mabl deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ buildNumber.properties
 *.iml
 *.iws
 work/
+
+# macOS system files
+.DS_Store
+**/.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.8.0</version>
+            <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepBuilder.java
@@ -81,6 +81,8 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     private boolean disableSslVerification;
     private String apiBaseUrl;
     private String appBaseUrl;
+    private String webUrlOverride;
+    private String apiUrlOverride;
 
     @DataBoundConstructor
     public MablStepBuilder(
@@ -132,6 +134,14 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
         this.appBaseUrl = appBaseUrl;
     }
 
+    @DataBoundSetter
+    public void setWebUrlOverride(String webUrlOverride) {this.webUrlOverride = webUrlOverride;} // To change the webUrl dynamically if the user wants to change during deployment execution
+
+    @DataBoundSetter
+    public void setApiUrlOverride(String apiUrlOverride){
+        this.apiUrlOverride = apiUrlOverride; // To change the apiUrl dynamically if the user wants to change during deployment execution
+    }
+
     // Accessors to be used by Jelly UI templates
     public String getRestApiKeyId() {
         return restApiKeyId;
@@ -170,6 +180,10 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
     public String getApiBaseUrl() { return this.apiBaseUrl; }
 
     public String getAppBaseUrl() { return this.appBaseUrl; }
+
+    public String getWebUrlOverride() { return this.webUrlOverride; }
+
+    public String getApiUrlOverride() { return this.apiUrlOverride; }
 
     @Override
     public void perform(
@@ -211,7 +225,9 @@ public class MablStepBuilder extends Builder implements SimpleBuildStep {
                 continueOnMablError,
                 isCollectVars(),
                 getOutputFileLocation(workspace),
-                getEnvironmentVars(run, listener)
+                getEnvironmentVars(run, listener),
+                webUrlOverride,
+                apiUrlOverride
         );
     
         Executor executor = Executor.currentExecutor();

--- a/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
+++ b/src/main/java/com/mabl/integration/jenkins/MablStepDeploymentRunner.java
@@ -73,6 +73,9 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
     private final boolean collectVars;
     private final FilePath buildPath;
     private final EnvVars environmentVars;
+    private final String webUrlOverride;
+    private final String  apiUrlOverride;
+
 
     @SuppressWarnings("WeakerAccess") // required public for DataBound
     @DataBoundConstructor
@@ -88,7 +91,9 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
             final boolean continueOnMablError,
             final boolean collectVars,
             final FilePath buildPath,
-            final EnvVars environmentVars
+            final EnvVars environmentVars,
+            final String webUrlOverride,
+            final String apiUrlOverride
 
     ) {
         this.outputStream = outputStream;
@@ -103,6 +108,9 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         this.collectVars = collectVars;
         this.buildPath = buildPath;
         this.environmentVars = environmentVars;
+        this.webUrlOverride = webUrlOverride;
+        this.apiUrlOverride = apiUrlOverride;
+
     }
 
     @Override
@@ -198,6 +206,19 @@ public class MablStepDeploymentRunner implements Callable<Boolean> {
         }
 
         properties.setDeploymentOrigin(MablStepConstants.PLUGIN_USER_AGENT);
+        // Set URL overrides here if any.
+
+        if(webUrlOverride != null || apiUrlOverride != null) {
+            CreateDeploymentProperties.PlanOverride overrides = new CreateDeploymentProperties.PlanOverride();
+            overrides.setWebURL(webUrlOverride);
+            overrides.setApiUrl(apiUrlOverride);
+            properties.setPlanOverrides(overrides);
+
+            outputStream.printf("URL overrides set : %n web_url : [%s]%n api_url : [%s]%n",
+                    webUrlOverride == null ? "empty" : webUrlOverride,
+                    apiUrlOverride == null ? "empty" : apiUrlOverride
+            );
+        }
         return properties;
     }
 

--- a/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
+++ b/src/main/java/com/mabl/integration/jenkins/domain/CreateDeploymentProperties.java
@@ -12,6 +12,7 @@ public class CreateDeploymentProperties {
     private String buildPlanName;
     private String buildPlanNumber;
     private String buildPlanResultUrl;
+    private PlanOverride planOverrides;
 
     public String getDeploymentOrigin() {
         return deploymentOrigin;
@@ -57,6 +58,8 @@ public class CreateDeploymentProperties {
         return buildPlanResultUrl;
     }
 
+    public PlanOverride getPlanOverrides() {return planOverrides; }   // this it to override both api and web URL
+
     public void setDeploymentOrigin(String plugin) {
         this.deploymentOrigin = plugin;
     }
@@ -101,6 +104,8 @@ public class CreateDeploymentProperties {
         this.buildPlanResultUrl = buildPlanResultUrl;
     }
 
+    public void setPlanOverrides(PlanOverride planOverrides) { this.planOverrides = planOverrides; }
+
     public CreateDeploymentProperties copy() {
         CreateDeploymentProperties copy = new CreateDeploymentProperties();
         copy.setDeploymentOrigin(deploymentOrigin);
@@ -114,7 +119,37 @@ public class CreateDeploymentProperties {
         copy.setBuildPlanId(buildPlanName);
         copy.setBuildPlanNumber(buildPlanNumber);
         copy.setBuildPlanResultUrl(buildPlanResultUrl);
+
+        // To check if there is URL changes in plan and if does then update it
+        if(planOverrides != null){
+            PlanOverride overrideCopy = new PlanOverride();
+            overrideCopy.setWebURL(planOverrides.getWebURL());
+            overrideCopy.setApiUrl(planOverrides.getApiURL());
+            copy.setPlanOverrides(overrideCopy);
+        }
         return copy;
+    }
+
+
+    //InnerClass to change the new plans according to webURL Change and ApiURl Change
+    public static class PlanOverride{
+        private String webURL;
+        private String apiURL;
+
+        public void setWebURL(String webURL) {
+            this.webURL = webURL;
+        }
+
+        public void setApiUrl(String apiURL) {
+            this.apiURL = apiURL;
+        }
+
+        public String getWebURL() {
+            return webURL;
+        }
+        public String getApiURL() {
+            return apiURL;
+        }
     }
 }
 

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/config.jelly
@@ -31,6 +31,12 @@
     <f:entry title="${%Disable SSL verification}" field="disableSslVerification">
       <f:checkbox default="false" />
     </f:entry>
+    <f:entry title="${%Web URL Override}" field="webUrlOverride">
+      <f:textbox/>
+    </f:entry>
+    <f:entry title="${%API URL Override}" field="apiUrlOverride">
+      <f:textbox/>
+    </f:entry>
   </f:advanced>
   <f:validateButton
       title="${%Validate}" progress="${%Validating...}"

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-apiUrlOverride.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-apiUrlOverride.html
@@ -1,0 +1,3 @@
+<div>
+    Override the default API URL that will be used during mabl test execution. This allows you to direct API tests to a specific endpoint or service without changing the mabl configuration.
+</div>

--- a/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-webUrlOverride.html
+++ b/src/main/resources/com/mabl/integration/jenkins/MablStepBuilder/help-webUrlOverride.html
@@ -1,0 +1,3 @@
+<div>
+  Override the default web URL that will be used during mabl test execution. This allows you to direct tests to a specific environment or endpoint without changing the mabl configuration.
+</div>

--- a/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
+++ b/src/test/java/com/mabl/integration/jenkins/MablStepDeploymentRunnerTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.io.ByteArrayOutputStream;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
@@ -35,7 +36,8 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
+//import static org.mockito.Mockito;
+//import static org.mockito.MockSettings;
 /**
  * Unit test runner
  */
@@ -51,6 +53,8 @@ public class MablStepDeploymentRunnerTest {
     private final String eventId = "foo-event-id";
     private final FilePath buildPath = new FilePath(new File("/dev/null"));
     private final EnvVars envVars = new EnvVars();
+    private final String webUrlOverride = "https://test-web-override.example.com";
+    private final String apiUrlOverride = "https://test-api-override.example.com";
 
     private MablStepDeploymentRunner runner;
     private MablRestApiClient client;
@@ -75,7 +79,9 @@ public class MablStepDeploymentRunnerTest {
                 false,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
     }
 
@@ -160,7 +166,9 @@ public class MablStepDeploymentRunnerTest {
                 true,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
 
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), eq(labels), isNull(), any(CreateDeploymentProperties.class)))
@@ -185,7 +193,9 @@ public class MablStepDeploymentRunnerTest {
                 false,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
 
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), eq(labels), isNull(), any(CreateDeploymentProperties.class)))
@@ -214,7 +224,9 @@ public class MablStepDeploymentRunnerTest {
                 false,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
 
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), eq(labels), isNull(), any(CreateDeploymentProperties.class)))
@@ -242,7 +254,9 @@ public class MablStepDeploymentRunnerTest {
                 false,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
 
         when(client.createDeploymentEvent(eq(environmentId), eq(applicationId), eq(labels), isNull(), any(CreateDeploymentProperties.class)))
@@ -270,7 +284,9 @@ public class MablStepDeploymentRunnerTest {
                 false,
                 true,
                 buildPath,
-                envVars
+                envVars,
+                null,
+                null
         );
 
         final CreateDeploymentResult createDeploymentResult = new CreateDeploymentResult(eventId, "workspace-w");


### PR DESCRIPTION
added two new fields in the Advanced section of our build step:

Web URL Override - lets users specify an alternative web URL for tests
API URL Override - similar, but for API endpoints

Modified deployment properties to add these two values.